### PR TITLE
disable initialization of (g)vimrc files

### DIFF
--- a/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/cli.rb
@@ -65,7 +65,7 @@ module VimGolf
         # - n - no swap file, memory only editing
         # - --noplugin - don't load any plugins, lets be fair!
         # - +0 - always start on line 0
-        system("vim -n --noplugin +0 -W #{log(id)} #{input(id, type)}")
+        system("vim -n --noplugin -u NONE -U NONE +0 -W #{log(id)} #{input(id, type)}")
 
         if $?.exitstatus.zero?
           diff = `diff --strip-trailing-cr #{input(id, type)} #{output(id)}`


### PR DESCRIPTION
this should even the playing field a bit and prevent cheating by putting custom scripts in your ~/vimrc files
