### PR TITLE
Plugging a few cheating holes...

### DIFF
--- a/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/cli.rb
@@ -64,8 +64,10 @@ module VimGolf
 
         # - n - no swap file, memory only editing
         # - --noplugin - don't load any plugins, lets be fair!
+        # -u NONE and -U none - don't load .vimrc or .gvimrc
+        # -i NONE - don't load .viminfo (for saved macros and the like)
         # - +0 - always start on line 0
-        system("vim -n --noplugin -u NONE -U NONE +0 -W #{log(id)} #{input(id, type)}")
+        system("vim -n --noplugin -u NONE -U NONE -i NONE +0 -W #{log(id)} #{input(id, type)}")
 
         if $?.exitstatus.zero?
           diff = `diff --strip-trailing-cr #{input(id, type)} #{output(id)}`


### PR DESCRIPTION
This plugs a few cheating methods in vimgolf. It's not like you can't still cheat, but it should get rid of common cases.

I think the only sure-fire way to prevent cheating is to a) have a server-hosted version you telnet to, or b) run the log submission through a server-side instance of vim to validate it works there on a clean filesystem.
