### PR TITLE
fix EOFError repeatedly returned by HighLine::ask on stock osx ruby

### DIFF
--- a/lib/vimgolf/ui.rb
+++ b/lib/vimgolf/ui.rb
@@ -61,6 +61,7 @@ module VimGolf
           @hl.ask(message, options[:choices] || [], &details)
         rescue EOFError
           # be sure to exit, don't loop
+          error "Argh! Forced quit due to EOF error. Please report this problem so we can fix it!"
           return :quit
         end
       end


### PR DESCRIPTION
ruby 1.8.7 (2011-12-28 patchlevel 357) [universal-darwin11.0]

closes #94
