### PR TITLE
Raise Interrupt instead of StandardExit

### DIFF
--- a/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/cli.rb
@@ -105,7 +105,7 @@ module VimGolf
                 challenge.start
                 raise RetryException
               when :quit
-                raise StandardExit
+                raise Interrupt
               end
             end
           end
@@ -128,12 +128,12 @@ module VimGolf
               raise RetryException
             when :x
               next unless upload?(challenge)
-              raise StandardExit
+              raise Interrupt
             when :retry
               challenge.start
               raise RetryException
             when :quit
-              raise StandardExit
+              raise Interrupt
             end
           end
 
@@ -150,7 +150,7 @@ module VimGolf
         retry
       end
 
-    rescue Interrupt, StandardError, StandardExit
+    rescue Interrupt, StandardError
       VimGolf.ui.info "\nThanks for playing!"
     rescue Exception => e
       VimGolf.ui.error "Uh oh, something went wrong! Error: #{e}"


### PR DESCRIPTION
This fixes a bug when using Ruby 1.8, since it has no definition of
StandardExit:

"uninitialized constant VimGolf::CLI::StandardExit (NameError)"

Since Interrupt and StandardExit executed the same code when caught, we
just replaced all occurences of StandardExit by Interrupt.

The bug was introduced in 103e5279281bb3c6deed76f7b9c6d1558d74565e
