### PR TITLE
Play vimgolf on local files

### DIFF
--- a/lib/vimgolf.rb
+++ b/lib/vimgolf.rb
@@ -1,9 +1,12 @@
+require 'rubygems'
 require 'fileutils'
 require 'net/http'
 require 'strscan'
 require 'json'
 require 'yaml'
 require 'thor'
+require 'shellwords'
+require 'tempfile'
 
 require 'vimgolf/version'
 require 'vimgolf/config'

--- a/lib/vimgolf/challenge.rb
+++ b/lib/vimgolf/challenge.rb
@@ -109,7 +109,7 @@ module VimGolf
     attr_reader :log_path
     attr_reader :vimrc_path
 
-    def correct
+    def correct?
       FileUtils.compare_file(@work_path, @output_path)
     end
 

--- a/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/cli.rb
@@ -120,7 +120,7 @@ module VimGolf
           VimGolf.ui.print_log log
 
           # Handle incorrect solutions
-          if !challenge.correct()
+          if !challenge.correct?()
             VimGolf.ui.error "\nUh oh, looks like your entry does not match the desired output."
             VimGolf.ui.error "Your score for this failed attempt was: #{log.score}"
             loop do

--- a/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/cli.rb
@@ -2,7 +2,6 @@ module VimGolf
 
   GOLFDEBUG    = ENV['GOLFDEBUG'].to_sym rescue false
   GOLFHOST     = ENV['GOLFHOST']     || "http://www.vimgolf.com"
-  GOLFDIFF     = ENV['GOLFDIFF']     || 'diff'
   GOLFSHOWDIFF = ENV['GOLFSHOWDIFF'] || 'vim -d -n'
   GOLFVIM      = ENV['GOLFVIM']      || 'vim'
   PROXY        = ENV['http_proxy']   || ''
@@ -61,43 +60,69 @@ module VimGolf
       end
     end
 
-    desc "put [ID]", "launch Vim session"
+    desc "put CHALLENGE_ID", "launch vimgolf.com challenge"
     long_desc <<-DESC
     Launch a VimGolf session for the specified challenge ID. To find a currently
     active challenge ID, please visit vimgolf.com!
     DESC
 
-    def put(id = nil)
+    def put(id)
       FileUtils.mkdir_p Config.put_path
       VimGolf.ui.warn "Downloading Vimgolf challenge: #{id}"
       VimGolf::Challenge.path(Config.put_path)
       challenge = Challenge.new(id)
       challenge.download
 
+      play(challenge)
+    end
+
+    desc "local INFILE OUTFILE", "launch local challenge"
+    long_desc <<-DESC
+    Launch a local VimGolf challenge. A temporary copy of INFILE is made; the original files will not be touched.
+    DESC
+
+    def local(infile, outfile)
+      # make sure our files are sane
+      if !(File.file?(infile) and File.file?(outfile))
+        VimGolf.ui.error "INFILE and OUTFILE must exist and be regular files."
+        exit 1
+      end
+
+      challenge = Challenge.new(infile) # use the filename as id
+      challenge.local(infile, outfile)
+
+      play(challenge)
+    end
+
+    private
+
+    def play(challenge)
       begin
-        VimGolf.ui.warn "Launching VimGolf session for challenge: #{id}"
-        # - n - no swap file, memory only editing
-        # - +0 - always start on line 0
-        # - --noplugin - don't load any plugins, lets be fair!
-        # -i NONE - don't load .viminfo (for saved macros and the like)
-        # - u - load vimgolf .vimrc to level the playing field
-        vimcmd = "#{GOLFVIM} -Z -n --noplugin -i NONE +0 -u \"#{challenge.vimrc_path}\" -W \"#{challenge.log_path}\" \"#{challenge.work_path}\""
+        challenge.start
+        VimGolf.ui.warn "Launching VimGolf session for challenge: #{challenge.id}"
+        # -Z         - restricted mode, utilities not allowed
+        # -n         - no swap file, memory only editing
+        # --noplugin - don't load any plugins, lets be fair!
+        # --nofork   - otherwise GOLFVIM=gvim forks and returns immediately
+        # -i NONE    - don't load .viminfo (for saved macros and the like)
+        # +0         - always start on line 0
+        # -u vimrc   - load vimgolf .vimrc to level the playing field
+        # -U NONE    - don't load .gvimrc
+        # -W logfile - keylog file (overwrites if already exists)
+        vimcmd = GOLFVIM.shellsplit + %W{-Z -n --noplugin --nofork -i NONE +0 -u #{challenge.vimrc_path} -U NONE -W #{challenge.log_path} #{challenge.work_path}}
         debug(vimcmd)
-        system(vimcmd)
+        system(*vimcmd) # assembled as an array, bypasses the shell
 
         if $?.exitstatus.zero?
-          diff_files = "\"#{challenge.work_path}\" \"#{challenge.output_path}\""
-          diff = `#{GOLFDIFF} #{diff_files}`
           log = Keylog.new(IO.read(challenge.log_path))
 
           VimGolf.ui.info "\nHere are your keystrokes:"
           VimGolf.ui.print_log log
 
           # Handle incorrect solutions
-          if diff.size > 0
+          if !challenge.correct()
             VimGolf.ui.error "\nUh oh, looks like your entry does not match the desired output."
             VimGolf.ui.error "Your score for this failed attempt was: #{log.score}"
-
             loop do
               VimGolf.ui.warn "[d] Show diff"
               VimGolf.ui.warn "[r] Retry the current challenge"
@@ -108,10 +133,9 @@ module VimGolf
                                   :choices   => [:diff, :retry, :quit]
               when :diff
                 VimGolf.ui.warn "Showing vimdiff of your attempt (left) and correct output (right)"
-                system("#{GOLFSHOWDIFF} #{diff_files}")
+                system(*GOLFSHOWDIFF.shellsplit + [challenge.work_path, challenge.output_path])
               when :retry
                 VimGolf.ui.warn "Retrying current challenge..."
-                challenge.start
                 raise RetryException
               when :quit
                 raise Interrupt
@@ -123,6 +147,7 @@ module VimGolf
           VimGolf.ui.info "\nSuccess! Your output matches. Your score: #{log.score}"
 
           loop do
+            choices = []
             begin
               Config.load # raises error if user hasn't finished setup
               choices = [:w, :x]
@@ -131,7 +156,7 @@ module VimGolf
             rescue
               choices = [:setup]
               VimGolf.ui.warn "[s] Set up vimgolf.com key to submit result"
-            end
+            end if challenge.remote
             VimGolf.ui.warn "[r] Do not upload result and retry the challenge"
             VimGolf.ui.warn "[q] Do not upload result and quit"
 
@@ -140,7 +165,6 @@ module VimGolf
                                 :choices => choices + [:retry, :quit]
             when :w
               next unless upload?(challenge)
-              challenge.start
               raise RetryException
             when :x
               next unless upload?(challenge)
@@ -149,7 +173,6 @@ module VimGolf
               setup
               next # we can hopefully submit this time
             when :retry
-              challenge.start
               raise RetryException
             when :quit
               raise Interrupt
@@ -176,8 +199,6 @@ module VimGolf
       VimGolf.ui.error "Uh oh, something went wrong! Error: #{e}"
       VimGolf.ui.error "If the error persists, please report it to github.com/igrigorik/vimgolf"
     end
-
-    private
 
     def upload?(challenge)
       VimGolf.ui.warn "Uploading to VimGolf..."

--- a/lib/vimgolf/vimgolf.vimrc
+++ b/lib/vimgolf/vimgolf.vimrc
@@ -1,0 +1,28 @@
+" http://vimdoc.sourceforge.net/htmldoc/starting.html#vimrc
+
+set nocompatible        " use vim defaults
+set scrolloff=3         " keep 3 lines when scrolling
+set ai                  " set auto-indenting on for programming
+
+set showcmd             " display incomplete commands
+set nobackup            " do not keep a backup file
+set number              " show line numbers
+set ruler               " show the current row and column
+
+set hlsearch            " highlight searches
+set incsearch           " do incremental searching
+set showmatch           " jump to matches when entering regexp
+set ignorecase          " ignore case when searching
+set smartcase           " no ignorecase if Uppercase char present
+
+set visualbell t_vb=    " turn off error beep/flash
+set novisualbell        " turn off visual bell
+
+set backspace=indent,eol,start  " make that backspace key work the way it should
+set runtimepath=$VIMRUNTIME     " turn off user scripts, https://github.com/igrigorik/vimgolf/issues/129
+
+syntax on               " turn syntax highlighting on by default
+filetype on             " detect type of file
+filetype indent on      " load indent file for specific file type
+
+set t_RV=               " http://bugs.debian.org/608242, http://groups.google.com/group/vim_dev/browse_thread/thread/9770ea844cec3282


### PR DESCRIPTION
Introduces local play. You can take two local files and play Vimgolf on them. Good for:

* Testing challenges you're working on before submitting.
* Copy/pasting Vim strokes to forums and such. You can be sure the strokes you're posting actually work, and that there are no typos.
* Playing moar Vimgolf.

A few other changes had to be made to accommodate local play. They're all good changes anyway:

* The vimrc has to be included in the repository. (That's where it belongs anyway.) There's a security benefit too. It's possible for an attacker to intercept the json from vimgolf.com and put malicious stuff in the vimrc.
* Using temp files for work file and keylog.

I fixed another fairly severe security problem. Currently, the `@data['in']['type']` json field is taken straight from the Internet and stuck in three separate shell commands, unsanitized. An attacker can alter that field and shell-inject arbitrary code on the player's computer. The new version sanitizes the `@type` fields, and executes vim and vimdiff directly, without the shell. I simply replaced the diff call. (No more diff dependency!)

That and a few other things all ended up in 1 commit. Oh well.