### PR TITLE
Close tmp files, so Vim has them to itself

### DIFF
--- a/lib/vimgolf/challenge.rb
+++ b/lib/vimgolf/challenge.rb
@@ -24,9 +24,13 @@ module VimGolf
     def work_files
       @vimrc_path = File.expand_path('../vimgolf.vimrc', __FILE__)
 
-      # keep these temp files around so they don't close
+      # keep these Tempfile's around so they don't unlink
       @work = Tempfile.new(['vimgolf', ".#{@type}"])
       @log = Tempfile.new('golflog')
+      # close tmp files, but don't unlink
+      @work.close
+      @log.close
+
       @work_path = @work.path()
       @log_path = @log.path()
     end


### PR DESCRIPTION
On Windows, Vim saw that work_path was an already open file, because it was open in Ruby. Vim continued without warning on Unix, though having it open both places wasn't a great idea. Closing the files should fix the problem.