### PR TITLE
Open keylog files in binary mode

### DIFF
--- a/lib/vimgolf/challenge.rb
+++ b/lib/vimgolf/challenge.rb
@@ -91,7 +91,7 @@ module VimGolf
 
         proxy.start(url.host, url.port) do |http|
           request = Net::HTTP::Post.new(url.request_uri)
-          request.set_form_data({"challenge_id" => @id, "apikey" => Config.load['key'], "entry" => IO.read(log_path)})
+          request.set_form_data({"challenge_id" => @id, "apikey" => Config.load['key'], "entry" => IO.binread(log_path)})
           request["Accept"] = "application/json"
 
           res = http.request(request)

--- a/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/cli.rb
@@ -114,7 +114,7 @@ module VimGolf
         system(*vimcmd) # assembled as an array, bypasses the shell
 
         if $?.exitstatus.zero?
-          log = Keylog.new(IO.read(challenge.log_path))
+          log = Keylog.new(IO.binread(challenge.log_path))
 
           VimGolf.ui.info "\nHere are your keystrokes:"
           VimGolf.ui.print_log log

--- a/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/keylog.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: ASCII-8BIT
 
 module VimGolf
   class Keylog


### PR DESCRIPTION
#147 appears to be caused by opening log files in text mode. In Windows, when you read a file without binary mode and it contains a `^Z`, it counts as an EOF marker. Only text before a `<C-Z>` stroke was counted and reported to the server.

However, in Ruby >=1.9, opening a file in binary mode automatically sets the encoding to `ASCII-8BIT`. That's probably what it should be anyway, so I can just change the marker in keylog.rb. Problem is, this will probably not work on the server, unless the encoding of the log text is switched there too. Otherwise we'll see #100 again. I could also just change the encoding client-side (with some conditionals to keep Ruby 1.8 from breaking). Whatever's more convenient.
