### PR TITLE
Add feature specs for better integration coverage of web app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,6 @@ group :test, :development do
   gem "database_cleaner", "1.5.1"
   gem 'simplecov', :require => false
   gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem "capybara"
+  gem "pry-byebug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,12 +93,23 @@ GEM
       activemodel (= 3.0.19)
       activesupport (= 3.0.19)
     activesupport (3.0.19)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (2.0.10)
     bson (1.1.5)
     bson_ext (1.1.5)
     builder (2.1.2)
+    byebug (9.0.6)
+    capybara (2.11.0)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     codeclimate-test-reporter (1.0.4)
       simplecov
+    coderay (1.1.1)
     dalli (2.7.6)
     database_cleaner (1.5.1)
     diff-lcs (1.2.5)
@@ -117,7 +128,9 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     memcachier (0.0.2)
+    method_source (0.8.2)
     mime-types (1.25.1)
+    mini_portile2 (2.1.0)
     mongo (1.1.5)
       bson (>= 1.1.5)
     mongoid (2.0.0.beta.20)
@@ -126,6 +139,8 @@ GEM
       tzinfo (~> 0.3.22)
       will_paginate (~> 3.0.pre)
     newrelic_rpm (3.17.2.327)
+    nokogiri (1.7.0)
+      mini_portile2 (~> 2.1.0)
     oauth (0.5.1)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
@@ -138,6 +153,14 @@ GEM
       omniauth-oauth (~> 1.1)
     polyglot (0.3.5)
     power_assert (0.4.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    public_suffix (2.0.5)
     rack (1.2.8)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -169,6 +192,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     test-unit (3.2.3)
       power_assert
     thor (0.14.6)
@@ -181,6 +205,8 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     will_paginate (3.1.5)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -188,6 +214,7 @@ PLATFORMS
 DEPENDENCIES
   bson (= 1.1.5)
   bson_ext (= 1.1.5)
+  capybara
   codeclimate-test-reporter (~> 1.0.0)
   dalli
   database_cleaner (= 1.5.1)
@@ -198,6 +225,7 @@ DEPENDENCIES
   newrelic_rpm
   omniauth
   omniauth-twitter
+  pry-byebug
   rack-timeout
   rails (= 3.0.19)
   rails3_serve_static_assets!

--- a/spec/data/diff.txt
+++ b/spec/data/diff.txt
@@ -1,0 +1,5 @@
+6a7
+> *temp var7 11
+9a11,12
+> New text.
+> 

--- a/spec/data/input.txt
+++ b/spec/data/input.txt
@@ -1,0 +1,10 @@
+*temp var1 0
+*temp var2 "hi"
+*temp var3 -1
+*temp var4 42
+*temp var5 "asdf"
+*temp var6 0
+
+Simple things we do all the time should be able to be done with very few keystrokes, but sometimes I find something I need to do makes me go, "There MUST be a better way."
+
+This challenge is just a simple movement and entering text at a certain place.

--- a/spec/data/output.txt
+++ b/spec/data/output.txt
@@ -1,0 +1,13 @@
+*temp var1 0
+*temp var2 "hi"
+*temp var3 -1
+*temp var4 42
+*temp var5 "asdf"
+*temp var6 0
+*temp var7 11
+
+Simple things we do all the time should be able to be done with very few keystrokes, but sometimes I find something I need to do makes me go, "There MUST be a better way."
+
+New text.
+
+This challenge is just a simple movement and entering text at a certain place.

--- a/spec/features/deleting_a_challenge_spec.rb
+++ b/spec/features/deleting_a_challenge_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+feature "Deleting a challenege" do
+  include OmniAuthHelper
+
+  before(:each) do
+    mock_omni_auth
+  end
+
+  scenario "as the owner of the challenge" do
+    user = User.create!(
+      nickname: ADMINS.first,
+      name: "foo",
+      uid: "123545",
+      image: "bar",
+      provider: "twitter"
+    )
+    challenge = Challenge.create!(
+      title: "challenge1",
+      description: "a sample challenge",
+      input: "aa",
+      output: "bb",
+      diff: "aabb",
+      user_id: user.id
+    )
+
+    visit root_path
+
+    click_link "Sign in with Twitter"
+    click_link "challenge1"
+    click_button "Delete Challenge"
+
+    expect(Challenge.count).to eq(0)
+  end
+
+  scenario "not as the owner of the challenge" do
+    user = User.create!(
+      nickname: "foo",
+      name: "bar",
+      uid: 545321,
+      image: "baz",
+      provider: "twitter"
+    )
+    challenge = Challenge.create!(
+      title: "challenge1",
+      description: "a sample challenge",
+      input: "aa",
+      output: "bb",
+      diff: "aabb",
+      user_id: user.id
+    )
+
+    visit root_path
+
+    click_link "challenge1"
+
+    expect(page).not_to have_text("Delete Challenge")
+    expect(Challenge.count).to eq(1)
+  end
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+feature "Sign In" do
+  include OmniAuthHelper
+
+  before(:each) do
+    mock_omni_auth
+  end
+
+  scenario "as a first-time user" do
+    visit root_path
+
+    click_link "Sign in with Twitter"
+
+    expect(current_path).to eq(root_path)
+    expect(page).to have_text "Welcome the science guy"
+  end 
+
+  scenario "as an existing user" do
+    user = User.create!(
+      nickname: "foo",
+      name: "bar",
+      uid: "123545",
+      image: "foo",
+      provider: "twitter"
+    )
+
+    visit root_path
+
+    click_link "Sign in with Twitter"
+
+    expect(page).to have_text "Welcome the science guy"
+    expect(user.reload.name).to eq("bill nye")
+  end
+end

--- a/spec/features/submitting_a_challenge_spec.rb
+++ b/spec/features/submitting_a_challenge_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+feature "Submitting a challenge" do
+  include OmniAuthHelper
+
+  before(:each) do
+    mock_omni_auth
+  end
+
+  scenario "with missing fields" do
+    visit root_path
+
+    click_link "Sign in with Twitter"
+
+    click_link "Submit challenge"
+
+    click_button "Create challenge"
+
+    expect(page).to have_text "Title can't be blank"
+    expect(page).to have_text "Description can't be blank"
+    expect(page).to have_text "Input is too short (minimum is 1 characters)"
+    expect(page).to have_text "Output is too short (minimum is 1 characters)"
+    expect(page).to have_text "Diff is too short (minimum is 1 characters)"
+  end
+
+  scenario "with properly filled out fields" do
+    visit root_path
+
+    click_link "Sign in with Twitter"
+
+    click_link "Submit challenge"
+
+    fill_in "Title", with: "Super hard challenge"
+    fill_in "Description", with: "Turn back now; it's impossible!"
+    attach_file("challenge_input", path_for_data_file("input.txt"))
+    attach_file("challenge_output", path_for_data_file("output.txt"))
+    attach_file("challenge_diff", path_for_data_file("diff.txt"))
+    click_button "Create challenge"
+
+    expect(current_path).to eq(challenge_path(Challenge.first))
+    expect(Challenge.count).to eq(1)
+  end
+
+  def path_for_data_file(file)
+    File.join(Rails.root, "/spec/data/", file)
+  end
+end

--- a/spec/requests/submit_entry_spec.rb
+++ b/spec/requests/submit_entry_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+
+describe "POST /entry" do
+  it "creates an entry with a valid api key and valid challenge id" do
+    challenge = Challenge.create!(
+      title: "foo",
+      description: "bar",
+      input: "aa",
+      output: "bb",
+      diff: "aabb"
+    )
+    user = User.create!(
+      name: "bill nye",
+      image: "foo",
+      uid: 1,
+      provider: "github",
+      nickname: "the science guy"
+    )
+    body = { entry: "aa", challenge_id: challenge.id.to_s, apikey: user.key }.to_json
+
+    post("/entry", body, headers)
+
+    entries = challenge.reload.entries
+    expect(response).to have_http_status(200)
+    expect(json_response[:status]).to eq("ok")
+    expect(entries.count).to eq(1)
+    expect(entries.first.script).to eq("aa")
+    expect(entries.first.score).to eq(2)
+    expect(entries.first.created_at).not_to be nil
+    expect(entries.first.user).to eq(user)
+  end
+
+  it "fails for an invalid challenge id" do
+    challenge = Challenge.create!(
+      title: "foo",
+      description: "bar",
+      input: "aa",
+      output: "bb",
+      diff: "aabb"
+    )
+    invalid_challenge_id = BSON::ObjectId.from_string(challenge.id.to_s.reverse).to_s
+    body = { entry: "foo", challenge_id: invalid_challenge_id, apikey: "a" }.to_json
+
+    post("/entry", body, headers)
+
+    expect(response).to have_http_status(400)
+    expect(json_response[:status]).to eq("failed")
+  end
+
+  it "fails with an invalid api key" do
+    challenge = Challenge.create!(
+      title: "foo",
+      description: "bar",
+      input: "aa",
+      output: "bb",
+      diff: "aabb"
+    )
+    invalid_key = User.create!(
+      name: "bill nye",
+      image: "foo",
+      uid: 1,
+      provider: "github",
+      nickname: "the science guy"
+    ).key.reverse
+    body = { entry: "foo", challenge_id: challenge.id, apikey: invalid_key }.to_json
+
+    post("/entry", body, headers)
+
+    expect(response).to have_http_status(400)
+    expect(json_response[:status]).to eq("failed")
+  end
+
+  it "fails with an empty api key" do
+    body = { entry: "foobar", challenge_id: 1, apikey: "" }.to_json
+
+    post("/entry", body, headers)
+
+    expect(response).to have_http_status(400)
+    expect(json_response[:status]).to eq("failed")
+  end
+
+  it "fails with a missing challenge id" do
+    body = { entry: "foobar" }.to_json
+
+    post("/entry", body, headers)
+
+    expect(response).to have_http_status(400)
+    expect(json_response[:status]).to eq("failed")
+  end
+
+  it "fails when you're cheating" do
+    body = { entry: "a" }.to_json
+
+    post("/entry", body, headers)
+
+    expect(response).to have_http_status(400)
+    expect(json_response[:status]).to eq("failed")
+  end
+
+  def json_response
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def headers
+    {
+      "CONTENT_TYPE" => "application/json",
+      "HTTP_ACCEPT" => "application/json"
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'rspec/rails'
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+Capybara.default_driver = :rack_test
 
 RSpec.configure do |config|
   config.mock_with :rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  config.before(:each) do
+    OmniAuth.config.mock_auth[:twitter] = nil
+  end
+
   config.around(:each) do |example|
     DatabaseCleaner.cleaning do
       example.run

--- a/spec/support/omni_auth_helper.rb
+++ b/spec/support/omni_auth_helper.rb
@@ -1,0 +1,15 @@
+module OmniAuthHelper
+  def mock_omni_auth
+    OmniAuth.config.test_mode = true
+
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
+      provider: "twitter",
+      uid: "123545",
+      info: {
+        name: "bill nye",
+        nickname: "the science guy",
+        image: "foo.jpg"
+      }
+    })
+  end
+end


### PR DESCRIPTION
i decided to target one of the most important endpoints first which is the `/entry` endpoint that the gem uses to submit challenge entries. i noticed it was basically a json endpoint so it's best not to use capybara to test it. I used a request spec which is most common for api endpoints.

_note_: ~i'll be breaking up the feature specs into a number of PRs to make them more digestible and easier to review.~ they're broken up into digestible commits. i decided i didn't want to have to deal with rebasing, _but_ upon request i can close this one and make separate PRs if people wish. also, once #186 is merged ill change this to use factories.