### PR TITLE
Test just cli, or web AND cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
 language: ruby
-rvm:
-    - 2.1.5
+matrix:
+  include:
+    - rvm: 2.1.5 # Test web AND cli with specific version
+      gemfile: Gemfile
+    # Otherwise test only the cli
+    - rvm: 1.9
+      gemfile: lib/vimgolf/Gemfile
+    - rvm: 2.3
+      gemfile: lib/vimgolf/Gemfile
+
 services: mongodb
+before_install:
+    - ls -l /home/travis/.rvm/gems # Future reference, targets for quick build
+    - cd `dirname $BUNDLE_GEMFILE`
+    - pwd # For debug info
+    - gem update bundler # Travis's Bundler 1.7.6 is causing problems
+script: bundle exec rake
 addons:
   code_climate:
     repo_token: 87b58d792ac24c87c9eb7957aa3fe7e05f72f800619452853270ed6a8f5b3853

--- a/lib/vimgolf/.rspec
+++ b/lib/vimgolf/.rspec
@@ -1,0 +1,4 @@
+--color
+--pattern spec/lib/**/*_spec.rb
+--default-path ../../
+-I ../../spec

--- a/lib/vimgolf/Rakefile
+++ b/lib/vimgolf/Rakefile
@@ -4,7 +4,8 @@ Bundler::GemHelper.install_tasks
 require 'rspec/core/rake_task'
 
 desc "Run all RSpec tests"
-RSpec::Core::RakeTask.new(:spec)
+# rspec-core <3.5 bug overrides pattern given in .rspec
+RSpec::Core::RakeTask.new(:spec).pattern = 'spec/lib/**/*_spec.rb'
 
 task :default => :spec
 task :test => [:spec]

--- a/spec/cli_helper.rb
+++ b/spec/cli_helper.rb
@@ -1,0 +1,16 @@
+require 'vimgolf'
+require 'stringio'
+
+module Kernel
+  def capture_stdio(input = nil, &block)
+    org_stdin, $stdin = $stdin, StringIO.new(input) if input
+    org_stdout, $stdout = $stdout, StringIO.new
+    yield
+    return @out = $stdout.string
+  ensure
+    $stdout = org_stdout
+    $stdin = org_stdin
+  end
+  alias capture_stdout capture_stdio
+end
+

--- a/spec/lib/challenge_spec.rb
+++ b/spec/lib/challenge_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "cli_helper"
 require "tmpdir"
 require "fileutils"
 

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "cli_helper"
 
 describe VimGolf do
   it "provides VimGolf errors" do

--- a/spec/lib/keylog_spec.rb
+++ b/spec/lib/keylog_spec.rb
@@ -1,15 +1,15 @@
-require "spec_helper"
+require "cli_helper"
 
 include VimGolf
 
 describe VimGolf::Keylog do
 
-  Dir['spec/fixtures/*'].each do |f|
-    it "should parse #{f} logfile" do
+  Dir[File.join(File.dirname(__FILE__), 'fixtures', '*')].each do |f|
+    it "should parse #{File.basename(f)} logfile" do
       expect { Keylog.new(IO.read(f)).convert }.not_to raise_error
     end
 
-    it "should score #{f} logfile" do
+    it "should score #{File.basename(f)} logfile" do
       expect { Keylog.new(IO.read(f)).convert }.not_to raise_error
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,19 +10,6 @@ require 'rspec/rails'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-module Kernel
-  def capture_stdio(input = nil, &block)
-    org_stdin, $stdin = $stdin, StringIO.new(input) if input
-    org_stdout, $stdout = $stdout, StringIO.new
-    yield
-    return @out = $stdout.string
-  ensure
-    $stdout = org_stdout
-    $stdin = org_stdin
-  end
-  alias capture_stdout capture_stdio
-end
-
 RSpec.configure do |config|
   config.mock_with :rspec
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
It's useful to test the cli without needing to install rails or mongodb.
You should still be able to run all the tests from the project root as
before, but now running `rake` or `rspec` from the CLI root runs just those
tests, without extra dependencies.

Also tries to make Travis test multiple versions of Ruby. The server
needs a particular version, but the CLI is expected to run on many
versions. On the non-server versions, Travis should only run the CLI
tests.