### PR TITLE
Link to vimgolf.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ $> vimgolf setup
 $> vimgolf put [challenge ID]
 ```
 
+# Playing from other editors
+
+## Emacs
+
+There's a lightly maintained interface to play VimGolf challenges in Emacs
+over at [vimgolf.el](https://github.com/timvisher/vimgolf.el)
+
 # VimGolf.com web app
 
 


### PR DESCRIPTION
I fixed up vimgolf.el and verified that all the functionality I expect to work does. I think it makes sense to maintain this as an entirely separate entity given that we're never going to allow submissions from Emacs to vimgolf the site. I think a link makes perfect sense and probably encourages people to develop other editor interfaces as well! :)