### PR TITLE
Add rspec after each block to reset `VimGolf.ui` attribute to imitate initial class load

### DIFF
--- a/spec/cli_helper.rb
+++ b/spec/cli_helper.rb
@@ -14,3 +14,9 @@ module Kernel
   alias capture_stdout capture_stdio
 end
 
+RSpec.configure do |config|
+  config.after(:each) do
+    # To imitate the initial class load before calling `VimGolf::CLI.start`
+    VimGolf.ui = VimGolf::UI.new
+  end
+end


### PR DESCRIPTION
you can trigger a failure with `bundle exec rspec --seed 15862 spec/lib/cli_spec.rb`.
essentially any time `VimGolf::CLI.start` is called before the `"sets up VimGolf.ui"` spec is run it will fail because the `VimGolf.ui` attribute has already been set and the state persists between specs.
i have a rails upgrade branch that adds in `--order rand` option for rspec which will see intermittent errors until this is pulled in 

also I added a couple reviewers based on github suggestions. hope that's ok :)