### PR TITLE
Update mongoid query syntax in prep for major version upgrades

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ ruby '2.1.5'
 
 gem 'rails', '3.2.22.5'
 
-gem 'mongo', '1.3.1'
-gem 'bson', '1.3.1'
-gem 'bson_ext', '1.3.1'
-gem 'mongoid', '2.2.1'
+gem 'mongo', '1.7.1'
+gem 'bson', '1.7.1'
+gem 'bson_ext', '1.7.1'
+gem 'mongoid', '2.6.0'
 
 gem 'json', '1.8.2'
 gem 'memcachier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,8 +45,9 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (3.0.3)
-    bson (1.3.1)
-    bson_ext (1.3.1)
+    bson (1.7.1)
+    bson_ext (1.7.1)
+      bson (~> 1.7.1)
     builder (3.0.4)
     byebug (9.0.6)
     capybara (2.11.0)
@@ -84,11 +85,11 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile2 (2.1.0)
-    mongo (1.3.1)
-      bson (>= 1.3.1)
-    mongoid (2.2.1)
-      activemodel (~> 3.0)
-      mongo (>= 1.3, < 1.4)
+    mongo (1.7.1)
+      bson (~> 1.7.1)
+    mongoid (2.6.0)
+      activemodel (~> 3.1)
+      mongo (~> 1.7)
       tzinfo (~> 0.3.22)
     multi_json (1.12.1)
     newrelic_rpm (3.17.2.327)
@@ -198,8 +199,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bson (= 1.3.1)
-  bson_ext (= 1.3.1)
+  bson (= 1.7.1)
+  bson_ext (= 1.7.1)
   capybara
   codeclimate-test-reporter (~> 1.0.0)
   dalli
@@ -208,8 +209,8 @@ DEPENDENCIES
   faker
   json (= 1.8.2)
   memcachier
-  mongo (= 1.3.1)
-  mongoid (= 2.2.1)
+  mongo (= 1.7.1)
+  mongoid (= 2.6.0)
   newrelic_rpm
   omniauth
   omniauth-twitter

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    @current_user ||= User.first(:conditions => {:uid => session[:user]}) if session[:user]
+    @current_user ||= User.where(uid: session[:user]).first if session[:user]
     @current_user
   end
 

--- a/app/controllers/entry_controller.rb
+++ b/app/controllers/entry_controller.rb
@@ -18,7 +18,7 @@ class EntryController < ApplicationController
 
     elsif params['challenge_id'] && !params['apikey'].empty? && !params['apikey'].nil?
       @challenge = Challenge.find(params['challenge_id']) rescue nil
-      @user = User.first(:conditions => {:key => params['apikey']}) rescue nil
+      @user = User.where(key: params['apikey']).first
 
       if @challenge && @user
         @entry = Entry.new(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,6 @@
 class SessionsController < ApplicationController
   def create
-    user = User.first(:conditions => {
-      :uid => request.env['omniauth.auth']['uid']
-    })
+    user = User.where(uid: request.env['omniauth.auth']['uid']).first
 
     if user.nil?
       user = User.create(request.env['omniauth.auth']['info'].merge({

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def show
-    @user = User.find(:conditions => {:nickname => params[:username]}).first
+    @user = User.where(nickname: params[:username]).first
     return redirect_to root_path if @user.nil?
 
     @contributed  = Challenge.where('user_id' => @user.id)


### PR DESCRIPTION
replacing old `find(conditions: {})` syntax with `where().first` syntax. this low of a version of `mongoid` doesn't support the more appropriate `find_by` syntax yet, unfortunately. im doing this now in prep for rails 4.0. also, bump `mongoid` and friends gems to 2.6.0 and 1.7.1 respectively. read through the CHANGELOGs and there's nothing scary in there. did a bunch of manual testing alongside the test suite and it's solid 👍 

doing this in prep for major version upgrades of the `mongoid` and `mongo` gems. the mongo community diverged with the release of mongoid 3.0. that community used their own mongodb driver `moped` which had issues for a while. it wasnt until the release of mongoid 5.0 that mongodb community took over the `mongoid` gem and made `mongo` (what we're currently using) the de facto mongodb driver. little bit of history of the whole thing is written about [here](https://www.mongodb.com/blog/post/announcing-ruby-driver-20-rewrite).

all this matters because we need to bump `mongoid` to at least 4.0 to allow for rails 4.0. i would _really_ like to not mess around with `moped` (since it was always kinda buggy) so im gonna try to bump us all the way to 5.0 where it uses `mongo` gem for mongodb driver again. `mongo` will also be bumped to 2.0 since it was a complete rewrite. this is probably not the proper place for this discussion but i figured id outline my plan in here for right now