### PR TITLE
Fix deprecations as a result of upgrading to rails 4

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,9 +6,6 @@ Vimgolf::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,5 +24,7 @@ Vimgolf::Application.configure do
 
   # Expands the lines which load assets
   config.assets.debug = true
+
+  config.eager_load = false
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,4 +55,6 @@ Vimgolf::Application.configure do
 
   # Generate digests for asset URLs
   config.assets.digest = true
+
+  config.eager_load = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,9 +7,6 @@ Vimgolf::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,4 +35,6 @@ Vimgolf::Application.configure do
   config.static_cache_control = "public, max-age=3600"
 
   config.assets.allow_debugging = true
+
+  config.eager_load = false
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -7,3 +7,4 @@
 
 secret = ENV.fetch('SECRET_TOKEN', SecureRandom.hex)
 Vimgolf::Application.config.secret_token = secret
+Vimgolf::Application.config.secret_key_base = secret

--- a/spec/lib/keylog_spec.rb
+++ b/spec/lib/keylog_spec.rb
@@ -2,24 +2,22 @@
 # Ruby 1.9 doesn't like our fancy string literals without this.
 require "cli_helper"
 
-include VimGolf
-
 describe VimGolf::Keylog do
 
   Dir[File.join(File.dirname(__FILE__), 'fixtures', '*')].each do |f|
     it "should parse #{File.basename(f)} logfile" do
-      expect { Keylog.new(IO.read(f)).convert }.not_to raise_error
+      expect { VimGolf::Keylog.new(IO.read(f)).convert }.not_to raise_error
     end
 
     it "should score #{File.basename(f)} logfile" do
-      expect { Keylog.new(IO.read(f)).convert }.not_to raise_error
+      expect { VimGolf::Keylog.new(IO.read(f)).convert }.not_to raise_error
     end
   end
 
   it "should correctly parse and count a variety of keycodes" do
     input = "\x01\x09\x1a\x1b\x1c\x1e !09\\\"'()Aa~\x7f\x80KC\x80kd\x80\xffXZZ"
     output = "<C-A><Tab><C-Z><Esc><C-\\><C-^> !09\\\"'()Aa~<C-?><k0><Down><C-@>ZZ"
-    log = Keylog.new(input)
+    log = VimGolf::Keylog.new(input)
     expect(log.convert).to eql(output)
     expect(log.score).to eql(24)
   end
@@ -32,7 +30,7 @@ describe VimGolf::Keylog do
     # Sanity check. Different rubies conspiring to mess up the test encodings.
     expect(bytes.encoding).not_to eql(text.encoding)
     # Not testing the actual output, just checking whether encoding matters
-    expect(Keylog.new(text).convert).to eql(Keylog.new(bytes).convert)
+    expect(VimGolf::Keylog.new(text).convert).to eql(VimGolf::Keylog.new(bytes).convert)
   end
 
   it "should treat newline characters literally" do
@@ -40,7 +38,7 @@ describe VimGolf::Keylog do
     input = "a\ra\na\r\na\n\r\n"
     output = "a<CR>a<NL>a<CR><NL>a<NL><CR><NL>"
 
-    log = Keylog.new(input)
+    log = VimGolf::Keylog.new(input)
     expect(log.convert).to eql(output)
   end
 
@@ -48,7 +46,7 @@ describe VimGolf::Keylog do
     input = "\x80\xfd\x35\x80\xfdbhello\x80\xfd\x61\x80\xfd\x62 world"
     output = "hello world"
 
-    log = Keylog.new(input)
+    log = VimGolf::Keylog.new(input)
     expect(log.convert).to eql(output)
     expect(log.score).to eql(11)
   end
@@ -57,7 +55,7 @@ describe VimGolf::Keylog do
     input = "\x80  hello"
     output = "<20-20>hello"
 
-    log = Keylog.new(input)
+    log = VimGolf::Keylog.new(input)
     expect(log.convert).to eql(output)
   end
   
@@ -66,7 +64,7 @@ describe VimGolf::Keylog do
     late   = "\x80\xfd\x54\x80\xfd\x55\x80\xfd\x56\x80\xfd\x57\x80\xfd\x2c"
     output = "<C-Left><C-Right><C-Home><C-End><LeftMouse>"
 
-    expect(Keylog.new(early, Time.utc(2016, 3)).convert).to eql(output)
-    expect(Keylog.new(late, Time.utc(2016, 5)).convert).to eql(output)
+    expect(VimGolf::Keylog.new(early, Time.utc(2016, 3)).convert).to eql(output)
+    expect(VimGolf::Keylog.new(late, Time.utc(2016, 5)).convert).to eql(output)
   end
 end


### PR DESCRIPTION
preparing for rails 4.1.x.

the dual secret key (`secret_token` and `secret_key_base`) is so that we can upgrade people's cookies without completely blowing out anything stored there, more details [here](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#action-pack)

we were including `VimGolf` (the gem module) at the top-level in the keylog spec which was causing `VimGolf::Challenge` from the gem to replace the `Challenge` rails model constant. this was causing failures in any rails spec that used the `Challenge` model. we had a few options for resolving this. i decided we didn't need to include the module at all (we could have done it inside the describe block), but instead fully qualify all classes from the gem with the proper namespace. this all manifested when we specifically set `eager_load` configs for all the environments.