### PR TITLE
Fix thousand of useless query per challenge

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -31,6 +31,6 @@ class Entry
 
   # Returns true is an entry was created by given user
   def owned_by?(current_user)
-    user == current_user
+    current_user && user_id == current_user.id
   end
 end


### PR DESCRIPTION
In development mode and production mode, was unable to load big
challenge because of tons of

D, [2018-05-28T02:35:48.115951 #25065] DEBUG -- : MONGODB |  | vimgolf.find | STARTED | {"find"=>"challenges", "filter"=>{"_id"=>BSON::ObjectId('55b18bbea9c2c30d04000001')}, "$clusterTime"=>{"clusterTime"=>#<BSON::Timestamp:0x0055a654605f90 @seconds=1527467726, @increment=1>, "signature"=>{"hash"=><BSON::Binary:0x47086434266700 type=gene...
D,