### PR TITLE
Avoid fetching EVERY entries when post comment

### DIFF
--- a/app/controllers/entry_controller.rb
+++ b/app/controllers/entry_controller.rb
@@ -6,7 +6,6 @@ class EntryController < ApplicationController
   def comment
     if @challenge.participator?(current_user) && @entry && params.fetch(:comment, {})[:text].present?
       @entry.comments.push Comment.new(:comment => params[:comment][:text], :nickname => current_user.nickname)
-      @challenge.save
     end
 
     redirect_to challenge_path(params[:challenge])


### PR DESCRIPTION
In development mode and production mode, was unable to comment on big challenge because of tons of request. (one request per entry !)

And so avoid timeout error

Comment 'validation' still works