### PR TITLE
Support neovim in vimgolf cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
     - rvm: 2.4.1 # Test web AND cli with specific version
       gemfile: Gemfile
     # Otherwise test only the cli
-    - rvm: 1.9
-      gemfile: lib/vimgolf/Gemfile
     - rvm: 2.3
       gemfile: lib/vimgolf/Gemfile
 

--- a/lib/vimgolf/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/lib/vimgolf/cli.rb
@@ -109,7 +109,10 @@ module VimGolf
         # -u vimrc   - load vimgolf .vimrc to level the playing field
         # -U NONE    - don't load .gvimrc
         # -W logfile - keylog file (overwrites if already exists)
-        vimcmd = GOLFVIM.shellsplit + %W{-Z -n --noplugin --nofork -i NONE +0 -u #{challenge.vimrc_path} -U NONE -W #{challenge.log_path} #{challenge.work_path}}
+        vimcmd = GOLFVIM.shellsplit + %W{-Z -n --noplugin -i NONE +0 -u #{challenge.vimrc_path} -U NONE -W #{challenge.log_path} #{challenge.work_path}}
+        if GOLFVIM == "gvim"
+          vimcmd += %W{ --nofork}
+        end
         debug(vimcmd)
         system(*vimcmd) # assembled as an array, bypasses the shell
 


### PR DESCRIPTION
The '--nofork' option is invalid for neovim. 
It is also stated in comment on line 106 that '--nofork' option is only required for gvim.
So, it is more logical to have this option for gvim only not for vim or neovim. 
This code is tested with 'vim', 'neovim' and 'gvim' (vim-gtk3) and it is working without any error.
Solves #162