### PR TITLE
Profile page: Add list of played challenge

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,12 @@
-require_relative '../repositories/repository_challenge'
+require_relative '../services/show_profile'
 
 class UsersController < ApplicationController
 
   def show
-    @user = User.where(nickname: params[:username]).first
-    return redirect_to root_path if @user.nil?
+    user = User.where(nickname: params[:username]).first
+    return redirect_to root_path unless user
 
-    @contributed = RepositoryChallenge.created_by(@user.id).to_a
+    @show_profile = ShowProfile.new(user)
 
     respond_to do |format|
       format.html

--- a/app/repositories/repository_challenge.rb
+++ b/app/repositories/repository_challenge.rb
@@ -162,7 +162,7 @@ module RepositoryChallenge
           "created_at": { "$first": '$entries.created_at' },
           "script": { "$first": '$entries.script' },
           "comments": { "$first": '$entries.comments' },
-          "min_score": { "$min": '$entries.score'}
+          "min_score": { "$first": '$entries.score'}
         }
       },
       { "$sort": { "min_score": 1, "created_at": 1 } },
@@ -324,6 +324,40 @@ module RepositoryChallenge
           "count_entries": {
             "$size":  { "$ifNull": [ "$entries", [] ] }
           }
+        },
+      }
+    )
+  end
+
+  def self.player_best_scores(player_id)
+    collection_aggregate(
+      { "$match": { "entries.user_id": player_id } },
+      {
+        "$project": {
+          "_id": 1,
+          "title": 1,
+          "description": 1,
+          "entries": 1,
+          "count_entries": {
+            "$size":  { "$ifNull": [ "$entries", [] ] }
+          },
+          "best_score": {
+            "$min": "$entries.score"
+          },
+        }
+      },
+      { "$unwind": "$entries" },
+      { "$match": { "entries.user_id": player_id } },
+      { "$sort": { "entries.score": 1 } },
+      {
+        "$group": {
+          "_id": '$_id',
+          "title": { "$first": '$title'},
+          "description": { "$first": '$description'},
+          "count_entries": { "$first": '$count_entries'},
+          "best_score": { "$first": '$best_score'},
+          "best_player_score": { "$first": '$entries.score'},
+          "attempts": { "$sum":  1 }
         },
       }
     )

--- a/app/services/show_profile.rb
+++ b/app/services/show_profile.rb
@@ -1,0 +1,27 @@
+require_relative '../repositories/repository_challenge'
+require 'forwardable'
+
+# retieve specific data for show page
+# avoid loading all 'entries' to limit memory
+class ShowProfile
+  extend Forwardable
+
+  def initialize(player)
+    @player = player
+  end
+  attr_reader :player
+
+  def_delegators :player, :nickname
+  def_delegators :player, :name
+  def_delegators :player, :description
+  def_delegators :player, :location
+
+  def contributed
+    @contributed ||= RepositoryChallenge.created_by(player.id).to_a
+  end
+
+  def tried_challenges
+    @tried_challenges ||= RepositoryChallenge.player_best_scores(player.id).to_a
+  end
+
+end

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -1,21 +1,34 @@
 <div class="grid_7">
 
-    <% if @contributed.present? %>
+  <h3><b>Played Challenges</b></h3>
+    <% @show_profile.tried_challenges.each do |player_challenge| %>
+        <div>
+            <%= render partial: "shared/challenge", locals: { challenge: player_challenge } %>
+            <ul>
+              <li>Best score: <b><%= player_challenge['best_score'] %></b></li>
+              <li>Best player score: <b><%= player_challenge['best_player_score'] %></b></li>
+              <li>Number of attempts: <b><%= player_challenge['attempts'] %></b></li>
+            </ul>
+        </div>
+    <% end %>
+
+    <% if @show_profile.contributed.present? %>
         <h3><b>Contributed Challenges</b></h3>
-        <%= render partial: "shared/challenge", collection: @contributed, as: :challenge %>
+        <%= render partial: "shared/challenge", collection: @show_profile.contributed, as: :challenge %>
     <% end %>
 
 </div>
 
 <div class="grid_5">
-    <div class="notice clearfix">
-        <%= twitter_avatar @user.nickname %>
+  <div class="notice clearfix">
+    <%= twitter_avatar @show_profile.nickname %>
 
-        <h6 style="margin-bottom:0">
-            <b><%= @user.name %></b><br/>Twitter: <%= twitter_profile(@user.nickname) %>
-        </h6>
-        <p style="margin-bottom:0"><em><%= @user.description || @user.location %></em></p>
-    </div>
+    <h6 style="margin-bottom:0">
+      <b><%= @show_profile.name %></b><br/>Twitter: <%= twitter_profile(@show_profile.nickname) %>
+    </h6>
+    <p style="margin-bottom:0"><em><%= @show_profile.description || @show_profile.location %></em></p>
+  </div>
 
-    <h2 style="padding:0em;margin:0.5em 1.5em">contributed <b class="stat"><%= @contributed.size %></b> challenges</h2>
+  <h2 style="padding:0em;margin:1em 1.5em 0.5em 1.5em">entered into <b class="stat"><%= @show_profile.tried_challenges.size %></b> challenges</h2>
+  <h2 style="padding:0em;margin:0.5em 1.5em">contributed <b class="stat"><%= @show_profile.contributed.size %></b> challenges</h2>
 </div>

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 feature "Display created challenge in profile" do
 
-  before(:each) do
+  before do
     @created_zero_challenge = User.create!(
       name: "bill nye",
       nickname: "zero.challenge",
@@ -42,6 +42,112 @@ feature "Display created challenge in profile" do
       visit profile_path(@created_one_challenge.nickname)
       expect(page).to have_text 'contributed 1 challenges'
       expect(page).to have_text 'title of challenge - 0 entries'
+    end
+  end
+
+end
+
+feature "Display played challenge in profile" do
+
+  before do
+    @played_zero_challenge = User.create!(
+      name: "euclid",
+      nickname: "played.zero.challenge",
+      provider: "foo",
+      image: "foo.jpg",
+      uid: 1283578
+    )
+
+    @played_two_challenges = User.create!(
+      name: "pythagoras",
+      nickname: "played.two.challenge",
+      provider: "foo",
+      image: "foo.jpg",
+      uid: 123588
+    )
+
+    creator = User.create!(
+      name: "descartes",
+      nickname: "creator",
+      provider: "foo",
+      image: "foo.jpg",
+      uid: 123603
+    )
+
+    challenge = Challenge.new(
+      :title => 'simple practical',
+      :description => :test,
+      :input => :a,
+      :output => :b,
+      :diff => :c,
+      user_id: creator.id,
+    )
+    challenge.save!
+    challenge.entries << Entry.new(
+      script: "script",
+      created_at: Time.now,
+      updated_at: Time.now,
+      user_id: @played_two_challenges.id,
+      score: 10
+    )
+
+    challenge.entries << Entry.new(
+      script: "script",
+      created_at: Time.now,
+      updated_at: Time.now,
+      user_id: @played_two_challenges.id,
+      score: 19
+    )
+
+    # lowest score
+    challenge.entries << Entry.new(
+      script: "script",
+      created_at: Time.now,
+      updated_at: Time.now,
+      user_id: creator.id,
+      score: 3
+    )
+
+    challenge_other = Challenge.new(
+      :title => 'clean number',
+      :description => :test,
+      :input => :a,
+      :output => :b,
+      :diff => :c,
+      user_id: creator.id,
+    )
+    challenge_other.save!
+    challenge_other.entries << Entry.new(
+      script: "script",
+      created_at: Time.now,
+      updated_at: Time.now,
+      user_id: @played_two_challenges.id,
+      score: 1
+    )
+
+  end
+
+  context 'User did not played any challenge' do
+    scenario 'it display 0 played challenges' do
+      visit profile_path(@played_zero_challenge.nickname)
+      expect(page).to have_text 'entered into 0 challenges'
+    end
+  end
+
+  context 'User played some challenge' do
+    scenario 'it display informations about challenges' do
+      visit profile_path(@played_two_challenges.nickname)
+      expect(page).to have_text 'entered into 2 challenges'
+
+      expect(page).to have_text 'simple practical - 3 entries'
+      expect(page).to have_text 'Best score: 3'
+      expect(page).to have_text 'Best player score: 10'
+      expect(page).to have_text 'Number of attempts: 2'
+
+      expect(page).to have_text 'clean number - 1 entries'
+      expect(page).to have_text 'Best score: 1'
+      expect(page).to have_text 'Best player score: 1'
+      expect(page).to have_text 'Number of attempts: 1'
     end
   end
 


### PR DESCRIPTION
Long time ago, we displayed user rank per challenge.
It slowed down application because of heavy data.

I didn't find any solution to simply get the rank from mongo
so I display these information to help user to guess it s rank:

- Best score
- Best player score
- Number of attempts