### PR TITLE
Fix derek wyatt vim tutorials link and use SSL where is possible

### DIFF
--- a/app/views/main/about.erb
+++ b/app/views/main/about.erb
@@ -52,8 +52,8 @@
 
     <h3><a name="resources"><b>Resources for learning Vim</b></a></h3>
     <ul>
-        <li><%= link_to "Vim Tutorial @ linuxconfig.org", "http://www.linuxconfig.org/Vim_Tutorial", :target => :_new %></li>
-        <li><%= link_to "Vim Tutorial Videos @ derekwyatt.org", "http://www.derekwyatt.org/vim/vim-tutorial-videos/", :target => :_new %></li>
+        <li><%= link_to "Vim Tutorial @ linuxconfig.org", "https://www.linuxconfig.org/Vim_Tutorial", :target => :_new %></li>
+        <li><%= link_to "Vim Tutorial Videos @ derekwyatt.org", "http://derekwyatt.org/vim/tutorials", :target => :_new %></li>
         <li><%= link_to "VimCasts", "http://vimcasts.org", :target => :_new %></li>
     </ul>
 
@@ -79,7 +79,7 @@
 <div class="grid_5">
  <h3>Getting in touch</h3>
  <ul>
-    <li><b><a href="http://twitter.com/vimgolf">@vimgolf</a></b> on twitter</li>
+    <li><b><a href="https://twitter.com/vimgolf">@vimgolf</a></b> on twitter</li>
     <li><b>#VimGolf</b> on freenode (IRC)</li>
     <li><a href="https://github.com/igrigorik/vimgolf/issues">Open issues on GitHub</a></li>
     <li><a href="https://github.com/igrigorik/vimgolf">CLI source code on Github</a></li>


### PR DESCRIPTION
This PR will fix the tutorials link from Derek Wyatt in about page:
~http://derekwyatt.org/vim/vim-tutorial-videos~ to http://derekwyatt.org/vim/tutorials
and use the https version of some links where SSL certificate is valid