### PR TITLE
Remove KE_SNIFF handling.

### DIFF
--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -28,6 +28,10 @@ module VimGolf
         n = c.ord
         if n == 0x80
           b2, b3 = scanner.get_byte, scanner.get_byte
+          if b2 == "\xfd" && b3 >= "\x38" && @time > SNIFF_DATE
+            # Should we account for KE_SNIFF removal?
+            b3 = (b3.ord + 1).chr
+          end
           code = KC_MBYTE[b2+b3]
           yield code if code # ignore "nil" keystrokes (like window focus)
         else

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -46,9 +46,6 @@ module VimGolf
     KC_1BYTE[0x0a] = "<NL>"
     KC_1BYTE[0x09] = "<Tab>"
 
-    # After this date, assume KE_SNIFF is removed
-    SNIFF_DATE = Time.utc(2016, 4)
-
     KC_MBYTE = Hash.new do |_h,k|
       '<' + k.bytes.map {|b| "%02x" % b}.join('-') + '>' # For missing keycodes
     end.update({
@@ -196,10 +193,7 @@ module VimGolf
       #"\xfd\x36" => "KE_TAB",
       #"\xfd\x37" => "KE_S_TAB_OLD",
 
-      # Vim 7.4.1433 removed KE_SNIFF. Unfortunately, this changed the
-      # offset of every keycode after it. Keycodes after this point should be
-      # accurate BEFORE that change.
-      #"\xfd\x38" => "KE_SNIFF",
+      #"\xfd\x38" => "KE_SNIFF_UNUSED",
       #"\xfd\x39" => "KE_XF1",
       #"\xfd\x3a" => "KE_XF2",
       #"\xfd\x3b" => "KE_XF3",

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -28,10 +28,6 @@ module VimGolf
         n = c.ord
         if n == 0x80
           b2, b3 = scanner.get_byte, scanner.get_byte
-          if b2 == "\xfd" && b3 >= "\x38" && @time > SNIFF_DATE
-            # Should we account for KE_SNIFF removal?
-            b3 = (b3.ord + 1).chr
-          end
           code = KC_MBYTE[b2+b3]
           yield code if code # ignore "nil" keystrokes (like window focus)
         else

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -28,7 +28,7 @@ module VimGolf
         n = c.ord
         if n == 0x80
           b2, b3 = scanner.get_byte, scanner.get_byte
-          if b2 == "\xfd" && b3 >= "\x38" && @time > SNIFF_DATE
+          if b2 == "\xfd" && b3 >= "\x38" && @time.between?(*NO_SNIFF_DATE_RANGE)
             # Should we account for KE_SNIFF removal?
             b3 = (b3.ord + 1).chr
           end
@@ -50,8 +50,8 @@ module VimGolf
     KC_1BYTE[0x0a] = "<NL>"
     KC_1BYTE[0x09] = "<Tab>"
 
-    # After this date, assume KE_SNIFF is removed
-    SNIFF_DATE = Time.utc(2016, 4)
+    # Between these dates, assume KE_SNIFF is removed.
+    NO_SNIFF_DATE_RANGE = [Time.utc(2016, 4), Time.utc(2017, 7)]
 
     KC_MBYTE = Hash.new do |_h,k|
       '<' + k.bytes.map {|b| "%02x" % b}.join('-') + '>' # For missing keycodes
@@ -201,8 +201,11 @@ module VimGolf
       #"\xfd\x37" => "KE_S_TAB_OLD",
 
       # Vim 7.4.1433 removed KE_SNIFF. Unfortunately, this changed the
-      # offset of every keycode after it. Keycodes after this point should be
-      # accurate BEFORE that change.
+      # offset of every keycode after it.
+      # Vim 8.0.0697 added back a KE_SNIFF_UNUSED to fill in for the
+      # removed KE_SNIFF.
+      # Keycodes after this point should be accurate for vim < 7.4.1433
+      # and vim > 8.0.0697.
       #"\xfd\x38" => "KE_SNIFF",
       #"\xfd\x39" => "KE_XF1",
       #"\xfd\x3a" => "KE_XF2",

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -46,6 +46,9 @@ module VimGolf
     KC_1BYTE[0x0a] = "<NL>"
     KC_1BYTE[0x09] = "<Tab>"
 
+    # After this date, assume KE_SNIFF is removed
+    SNIFF_DATE = Time.utc(2016, 4)
+
     KC_MBYTE = Hash.new do |_h,k|
       '<' + k.bytes.map {|b| "%02x" % b}.join('-') + '>' # For missing keycodes
     end.update({
@@ -193,7 +196,10 @@ module VimGolf
       #"\xfd\x36" => "KE_TAB",
       #"\xfd\x37" => "KE_S_TAB_OLD",
 
-      #"\xfd\x38" => "KE_SNIFF_UNUSED",
+      # Vim 7.4.1433 removed KE_SNIFF. Unfortunately, this changed the
+      # offset of every keycode after it. Keycodes after this point should be
+      # accurate BEFORE that change.
+      #"\xfd\x38" => "KE_SNIFF",
       #"\xfd\x39" => "KE_XF1",
       #"\xfd\x3a" => "KE_XF2",
       #"\xfd\x3b" => "KE_XF3",


### PR DESCRIPTION
I've recently implemented a vimgolf client in Python. It has a similar interface as the official client, but adds some features inspired by vimgolf-finder.
https://github.com/dstein64/vimgolf

I browsed the official Ruby code to assist me in my Python version. When browsing the code, I noticed the special handling for `KE_SNIFF`. This is no longer required, as vim now has a `KE_SNIFF_UNUSED` entry in keymap.h.

With the special handling, certain codes will be off-by-1. For example, using the current code on master, if I start a vimgolf challenge, and enter `<C-Left><C-Right>ZZ`, the vimgolf CLI will report the following key sequence:
`<C-Right><C-Home>ZZ`.

This PR fixes the issue by removing the special case handling.

I suppose most users of vimgolf are using the 0.4.8 gem version of vimgolf, which does not have this issue (presumably that version was implemented before vim originally removed `KE_SNIFF`.

