### PR TITLE
Include position in ranking for each challenge in user page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
     user = User.where(nickname: params[:username]).first
     return redirect_to root_path unless user
 
-    @show_profile = ShowProfile.new(user)
+    @show_profile = ShowProfile.new(user, params[:ranking])
 
     respond_to do |format|
       format.html

--- a/app/repositories/repository_challenge.rb
+++ b/app/repositories/repository_challenge.rb
@@ -376,6 +376,7 @@ module RepositoryChallenge
         "$group": {
           "_id": "$_id.challenge_id",
           "items": { "$push": "$$ROOT" },
+          "count_golfers": { "$sum": 1 },
         }
       },
       { "$unwind": { "path": "$items", "includeArrayIndex": "items.position" }},
@@ -391,7 +392,8 @@ module RepositoryChallenge
           "best_score": "$items.best_score",
           "best_player_score": "$items.best_player_score",
           "attempts": "$items.attempts",
-          "position": { "$add": ["$items.position", 1]}
+          "position": { "$add": ["$items.position", 1]},
+          "count_golfers": 1,
         }
       },
     )

--- a/app/services/show_profile.rb
+++ b/app/services/show_profile.rb
@@ -6,10 +6,12 @@ require 'forwardable'
 class ShowProfile
   extend Forwardable
 
-  def initialize(player)
+  def initialize(player, show_ranking = false)
     @player = player
+    @show_ranking = show_ranking
   end
   attr_reader :player
+  attr_reader :show_ranking
 
   def_delegators :player, :nickname
   def_delegators :player, :name
@@ -21,7 +23,7 @@ class ShowProfile
   end
 
   def tried_challenges
-    @tried_challenges ||= RepositoryChallenge.player_best_scores(player.id).to_a
+    @tried_challenges ||= RepositoryChallenge.player_best_scores(player.id, show_ranking).to_a
   end
 
 end

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -7,7 +7,9 @@
             <ul>
               <li>Best score: <b><%= player_challenge['best_score'] %></b></li>
               <li>Best player score: <b><%= player_challenge['best_player_score'] %></b></li>
+            <% if @show_profile.show_ranking %>
               <li>Position: <b>#<%= player_challenge['position'] %> / <%= player_challenge['count_golfers'] %></b></li>
+            <% end %>
               <li>Number of attempts: <b><%= link_to player_challenge['attempts'],
                 user_challenge_path(player_challenge['_id'], @show_profile.nickname) %></b></li>
             </ul>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -7,7 +7,7 @@
             <ul>
               <li>Best score: <b><%= player_challenge['best_score'] %></b></li>
               <li>Best player score: <b><%= player_challenge['best_player_score'] %></b></li>
-              <li>Position: <b>#<%= player_challenge['position'] %></b></li>
+              <li>Position: <b>#<%= player_challenge['position'] %> / <%= player_challenge['count_golfers'] %></b></li>
               <li>Number of attempts: <b><%= link_to player_challenge['attempts'],
                 user_challenge_path(player_challenge['_id'], @show_profile.nickname) %></b></li>
             </ul>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -7,6 +7,7 @@
             <ul>
               <li>Best score: <b><%= player_challenge['best_score'] %></b></li>
               <li>Best player score: <b><%= player_challenge['best_player_score'] %></b></li>
+              <li>Position: <b>#<%= player_challenge['position'] %></b></li>
               <li>Number of attempts: <b><%= link_to player_challenge['attempts'],
                 user_challenge_path(player_challenge['_id'], @show_profile.nickname) %></b></li>
             </ul>

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -420,7 +420,7 @@ describe RepositoryChallenge do
       end
 
       it 'return expected user information about the user' do
-        result = RepositoryChallenge.player_best_scores(user.id).to_a
+        result = RepositoryChallenge.player_best_scores(user.id, true).to_a
         expect(result.length).to eq(1)
         challenge = result.first
         expect(challenge['_id']).to eq(challenge1.id)
@@ -448,7 +448,7 @@ describe RepositoryChallenge do
       end
 
       it 'return expected user information about the user' do
-        result = RepositoryChallenge.player_best_scores(user.id).to_a
+        result = RepositoryChallenge.player_best_scores(user.id, true).to_a
         expect(result.length).to eq(2)
 
         # Ensure challenges are in chronological order, challenge2 is first.

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -430,6 +430,7 @@ describe RepositoryChallenge do
         expect(challenge['best_score']).to eq(10)
         expect(challenge['best_player_score']).to eq(12)
         expect(challenge['attempts']).to eq(2)
+        expect(challenge['position']).to eq(2)
       end
     end
 
@@ -459,6 +460,7 @@ describe RepositoryChallenge do
         expect(challenge['best_score']).to eq(14)
         expect(challenge['best_player_score']).to eq(14)
         expect(challenge['attempts']).to eq(1)
+        expect(challenge['position']).to eq(1)
 
         # And challenge1 is next.
         challenge = result[1]
@@ -469,6 +471,7 @@ describe RepositoryChallenge do
         expect(challenge['best_score']).to eq(10)
         expect(challenge['best_player_score']).to eq(12)
         expect(challenge['attempts']).to eq(2)
+        expect(challenge['position']).to eq(2)
       end
     end
 

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -461,6 +461,7 @@ describe RepositoryChallenge do
         expect(challenge['best_player_score']).to eq(14)
         expect(challenge['attempts']).to eq(1)
         expect(challenge['position']).to eq(1)
+        expect(challenge['count_golfers']).to eq(1)
 
         # And challenge1 is next.
         challenge = result[1]
@@ -472,6 +473,7 @@ describe RepositoryChallenge do
         expect(challenge['best_player_score']).to eq(12)
         expect(challenge['attempts']).to eq(2)
         expect(challenge['position']).to eq(2)
+        expect(challenge['count_golfers']).to eq(2)
       end
     end
 


### PR DESCRIPTION
Additionally to showing the best player score and the best score for the challenge, include the actual position of the best user score in the ranking for that particular challenge.

Since the query including the rankings is potentially too expensive, only perform the full query and include the rankings if `?ranking=1` is included in the URL, that way just browsing user pages normally will not suffer from the performance hit of the expensive query.

Benchmarking:


I created `db:setup` with `challenges=300 users=10000`, then I patched `db/seeds.db` to have most challenges have a random number of entries in the range 100..2,000, but 2% of them in the range 5,000..40,000, to provide a more realist test scenario. (Creating all challenges with 20,000 entries just made all queries too expensive from the start.)

With that setup, I measured the effects of loading a user page, for a user with entries in 36 challenges, which included all 6 challenges with over 5,000 entries. More specifically, the 6 top challenges ranged from 17,829 to 37,251 entries.

I then loaded this page 10 times, with and without the changes in this PR. I took the average and standard deviation of the 10 measurements for each situation.

 - Without this PR:  0.25547s ± 0.00663s
 - With this PR:     2.23918s ± 0.05312s

This is a roughly 9x increase, which is perhaps quite expensive to make it acceptable for the general case.
