### PR TITLE
Display all challenge solutions per user

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,8 +10,8 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
-      - javascript
+        ruby:
+        javascript:
   eslint:
     enabled: true
   fixme:
@@ -36,3 +36,4 @@ exclude_paths:
 - db/
 - script/
 - spec/
+- app/repositories/

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -69,6 +69,19 @@ class ChallengesController < ApplicationController
     end
   end
 
+  def user
+    # Limit to id to avoid downloading uneccessary entries
+    challenge_id = params['id']
+    challenge = Challenge.only(:id).find(challenge_id) rescue nil
+    return redirect_to root_path if challenge.nil?
+
+    player = User.where(nickname: params[:username]).first rescue nil
+    return redirect_to root_path if player.nil?
+
+    @show_challenge = ShowChallenge.new(challenge.id)
+    @submissions = SubmissionsPerUser.new(current_user, challenge.id, player)
+  end
+
   private
 
   def challenge_params

--- a/app/services/submissions.rb
+++ b/app/services/submissions.rb
@@ -69,6 +69,10 @@ class Submissions
     @user_id ||= Challenge.only(:user_id).find(challenge_id).user_id
   end
 
+  def highlight_owner?
+    true
+  end
+
   def creator?
     user_id == player.id
   end

--- a/app/services/submissions_per_user.rb
+++ b/app/services/submissions_per_user.rb
@@ -1,0 +1,112 @@
+require_relative '../repositories/repository_challenge'
+require_relative './solution'
+
+class SubmissionsPerUser
+
+  def initialize(current_user, challenge_id, player)
+    # @current_user is the logged in user, while @player is the user about
+    # which this per-challenge page is being shown.
+    #
+    # Note that this is different from Submission, in which @player refers
+    # to the current logged in user.
+    @current_user = current_user
+    @challenge_id = challenge_id
+    @player = player
+  end
+  attr_reader :challenge_id
+  attr_reader :player
+
+  def each
+    each_unfiltered do |s|
+      if visible_score && s.score >= visible_score
+        yield s
+      end
+    end
+  end
+
+  def each_unfiltered
+    # Adjust entries from the query. The position in the ranking from the first
+    # entry is correct, but the other entries are not actually in the ranking
+    # (only the best answer for each user is.)
+    #
+    # So, instead, we adjust it to show after which entry in the ranking it would
+    # have been, had the user not had a better entry than that one.
+    #
+    # To differentiate it visually, we display it as #>n instead of #n. For
+    # example, #>15 instead of #15 if your entry would come right after the one
+    # in position 15.
+    #
+    # `each_unfiltered` is used to list all scores of the user (where the
+    # Leaderboard normally is), while `each` is used to display the solutions
+    # that should be visible, assuming the logged in user has an entry with
+    # score low enough to allow displaying them.
+    adjust = 0
+    submissions.each do |s|
+      position = s['position'] - adjust
+      if adjust > 0
+        position = ">#{position}"
+      end
+      yield Solution.new(s, users, position)
+      adjust += 1
+    end
+  end
+
+  def empty?
+    submissions.none?
+  end
+
+  def users
+    @users ||= {player.id => player}
+  end
+
+  def submissions
+    @submissions ||= RepositoryChallenge.submissions_per_player(
+      challenge_id, player.id)
+  end
+
+  def visible_score
+    return @visible_score if defined?(@visible_score)
+
+    if !@current_user
+      @visible_score = nil
+    elsif @current_user.admin? || creator?
+      @visible_score = 0
+    else
+      # Player's score for this challenge, or nil if player hasn't
+      # made any submissions for this one.
+      @visible_score = RepositoryChallenge.best_player_score(challenge_id, @current_user.id)
+    end
+  end
+
+  def user_id
+    @user_id ||= Challenge.only(:user_id).find(challenge_id).user_id
+  end
+
+  def highlight_owner?
+    false
+  end
+
+  def creator?
+    user_id == @current_user.id
+  end
+
+  def player_can_edit?(_)
+    false
+  end
+  alias :player_can_delete? :player_can_edit?
+
+  def count_uniq_users
+    RepositoryChallenge.count_uniq_users(challenge_id)
+  end
+
+  def count_remaining
+    result = 0
+    each_unfiltered do |s|
+      if !(visible_score && s.score >= visible_score)
+        result += 1
+      end
+    end
+    result
+  end
+
+end

--- a/app/views/challenges/show.erb
+++ b/app/views/challenges/show.erb
@@ -2,16 +2,8 @@
 
 <div class="grid_7">
     <h3><b><%= @show_challenge.title %></b></h3>
-    <p><%= @show_challenge.description%></p>
 
-    <h5>Start file</h5>
-    <pre class="prettyprint"><%= @show_challenge.input %></pre>
-
-    <h5>End file</h5>
-    <pre class="prettyprint"><%= @show_challenge.output %></pre>
-
-    <h4><a href="#" onclick="toggle('diff'); return false;">View Diff</a></h4>
-    <pre class="prettyprint" id="diff"><%= @show_challenge.diff %></pre>
+  <%= render :partial => "shared/challenge_description", :locals => { show_challenge: @show_challenge } %>
 
     <h3>Solutions</h3>
     <p><b>The best way to learn is to practice</b>. Below, you will find some of the solutions other golfers have entered. To unlock higher ranked solutions, submit your own entry which does as well or better than the solutions you can currently see - climb the ladder!</p>
@@ -26,24 +18,12 @@
 
   <%= render :partial => "shared/submissions", :locals => { submissions: @submissions } %>
 
+<%= paginate @submissions.paginated, inner_window: 20, param_name: :submissions_page %>
+
 </div>
 
 <div class="grid_5">
-    <h5>Created by: <%= profile_link(@show_challenge.user.nickname) %>
-        <span style="float:right">
-            <%= tweet_button({
-            :via => "",
-            :url => current_url,
-            :text => "awesome VimGolf challenge: #{@show_challenge.title} @",
-            :related => ["vim", "learnvim"],
-            :count => "horizontal"
-            }) %>
-        </span>
-    </h5>
-
-    <h2 style="padding-bottom:1em; border-bottom: 1px dotted;">
-        <b class="stat"><%= @show_challenge.count_uniq_users %></b> active golfers, <b class="stat"><%= @show_challenge.count_entries %></b> entries
-    </h2>
+  <%= render :partial => "shared/challenge_credits", :locals => { show_challenge: @show_challenge } %>
 
     <% if @show_challenge.owner?(current_user) %>
         <div class="error clearfix">

--- a/app/views/challenges/show.erb
+++ b/app/views/challenges/show.erb
@@ -39,7 +39,8 @@
         <% @leaderboard.each do |entry, user, position| %>
             <div class="notice clearfix">
                 <%= twitter_avatar user.nickname %>
-                <div style="float:right; text-align:center;font-size:2.4em"><b><%= entry[:min_score] %></b></div>
+                <div style="float:right; text-align:center;font-size:2.4em"><b><%= link_to entry[:min_score],
+                  user_challenge_path(@show_challenge.id, user.nickname) %></b></div>
 
                 <h6 style="margin-bottom:0">
                     <a class="anchor" href="#<%= entry[:entry_id] %>"><b>#<%= position %></b></a> - <%= user.name %> / <%= profile_link(user.nickname) %>

--- a/app/views/challenges/user.erb
+++ b/app/views/challenges/user.erb
@@ -1,0 +1,46 @@
+<% challenge_id(@show_challenge) %>
+
+<div class="grid_7">
+    <h3><b><%= link_to(@show_challenge.title, challenge_path(@show_challenge.id)) %></b></h3>
+
+  <%= render :partial => "shared/challenge_description", :locals => { show_challenge: @show_challenge } %>
+
+  <% if @submissions.empty? %>
+    <h3>No solutions by <%= profile_link(@submissions.player.nickname) %> yet.</h3>
+
+  <% else %>
+    <h3>Solutions by <%= profile_link(@submissions.player.nickname) %>:</h3>
+  <% end %>
+
+  <%= render :partial => "shared/submissions", :locals => { submissions: @submissions } %>
+
+<% if !current_user %>
+    <div class="note clearfix">Unlock <b><%= @submissions.count_remaining %></b> remaining solutions by <b><%= link_to "signing in", "/auth/twitter?x_auth_access_type=read&use_authorize=true" %></b> and submitting your own entry</div>
+  <% elsif @submissions.count_remaining > 0 %>
+    <div class="note clearfix">Unlock <b><%= @submissions.count_remaining %></b> remaining solutions by submitting a higher ranked entry</div>
+<% end %>
+
+</div>
+
+<div class="grid_5">
+  <%= render :partial => "shared/challenge_credits", :locals => { show_challenge: @show_challenge } %>
+
+    <% if @submissions.empty? %>
+        <h5>No solutions by <%= profile_link(@submissions.player.nickname) %> yet.</h5>
+
+    <% else %>
+        <h5>Solutions by <%= profile_link(@submissions.player.nickname) %>:</h5>
+        <% @submissions.each_unfiltered do |solution| %>
+            <div class="notice clearfix">
+                <%= twitter_avatar solution.user.nickname %>
+                <div style="float:right; text-align:center;font-size:2.4em"><b><%= solution.score %></b></div>
+
+                <h6 style="margin-bottom:0">
+                    <a class="anchor" href="#<%= solution.id %>"><b>#<%= solution.position %></b></a> - <%= solution.user.name %> / <%= profile_link(solution.user.nickname) %>
+                </h6>
+                <p style="margin-bottom:0"><em><%= solution.created_at.strftime("%m/%d/%Y at %I:%M%p") %></em></p>
+            </div>
+        <% end %>
+    <% end %>
+
+</div>

--- a/app/views/shared/_challenge_credits.erb
+++ b/app/views/shared/_challenge_credits.erb
@@ -1,0 +1,16 @@
+<h5>Created by: <%= profile_link(show_challenge.user.nickname) %>
+    <span style="float:right">
+        <%= tweet_button({
+        :via => "",
+        :url => current_url,
+        :text => "awesome VimGolf challenge: #{show_challenge.title} @",
+        :related => ["vim", "learnvim"],
+        :count => "horizontal"
+        }) %>
+    </span>
+</h5>
+
+<h2 style="padding-bottom:1em; border-bottom: 1px dotted;">
+    <b class="stat"><%= show_challenge.count_uniq_users %></b> active golfers, <b class="stat"><%= show_challenge.count_entries %></b> entries
+</h2>
+

--- a/app/views/shared/_challenge_description.erb
+++ b/app/views/shared/_challenge_description.erb
@@ -1,0 +1,10 @@
+<p><%= show_challenge.description %></p>
+
+<h5>Start file</h5>
+<pre class="prettyprint"><%= show_challenge.input %></pre>
+
+<h5>End file</h5>
+<pre class="prettyprint"><%= show_challenge.output %></pre>
+
+<h4><a href="#" onclick="toggle('diff'); return false;">View Diff</a></h4>
+<pre class="prettyprint" id="diff"><%= show_challenge.diff %></pre>

--- a/app/views/shared/_submissions.erb
+++ b/app/views/shared/_submissions.erb
@@ -1,4 +1,4 @@
-<% submissions.each do |solution, user, position| %>
+<% submissions.each do |solution| %>
   <div class="<%= solution.owner?(current_user) ? "note" : "success" %> clearfix">
 
   <h6 style="margin-bottom:0.5em">
@@ -38,5 +38,3 @@
 
   </div>
 <% end %>
-
-<%= paginate submissions.paginated, inner_window: 20, param_name: :submissions_page %>

--- a/app/views/shared/_submissions.erb
+++ b/app/views/shared/_submissions.erb
@@ -1,5 +1,5 @@
 <% submissions.each do |solution| %>
-  <div class="<%= solution.owner?(current_user) ? "note" : "success" %> clearfix">
+  <div class="<%= submissions.highlight_owner? && solution.owner?(current_user) ? "note" : "success" %> clearfix">
 
   <h6 style="margin-bottom:0.5em">
         <a class="anchor" href="#<%= solution.id %>" name="<%= solution.id %>"><b>#<%= solution.position %></b></a>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -7,7 +7,8 @@
             <ul>
               <li>Best score: <b><%= player_challenge['best_score'] %></b></li>
               <li>Best player score: <b><%= player_challenge['best_player_score'] %></b></li>
-              <li>Number of attempts: <b><%= player_challenge['attempts'] %></b></li>
+              <li>Number of attempts: <b><%= link_to player_challenge['attempts'],
+                user_challenge_path(player_challenge['_id'], @show_profile.nickname) %></b></li>
             </ul>
         </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,11 @@ Vimgolf::Application.routes.draw do
   get "/entry/:challenge/delete/:entry",to: "entry#destroy", as: :delete_entry
   post "/entry/:challenge/comment/:entry", to: "entry#comment", as: :comment_entry
 
-  resources :challenges
+  resources :challenges do
+    member do
+      get 'user/:username', to: "challenges#user", as: :user, :constraints => { :username => /[^\/]+/ }
+    end
+  end
 
   get "/feed", to: "main#feed", defaults: {format: "rss"}
   get "/about", to: "main#about"

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -473,4 +473,54 @@ describe RepositoryChallenge do
     end
 
   end
+
+  describe '.submissions_per_player(challenge_id, player_id)' do
+    context 'when there are entries in challenge' do
+      let(:user1) { create(:user) }
+      let(:user2) { create(:user) }
+      let(:user3) { create(:user) }
+      let(:user4) { create(:user) }
+      let(:user5) { create(:user) }
+      let(:challenge) { create(:challenge) }
+
+      before do
+        challenge.entries <<  build(:entry, user: user1, score: 52, created_at: Time.new(2018,03,27))
+        challenge.entries <<  build(:entry, user: user5, score: 51, created_at: Time.new(2018,03,28))
+        challenge.entries <<  build(:entry, user: user2, score: 49, created_at: Time.new(2018,03,29))
+        challenge.entries <<  build(:entry, user: user3, score: 45, created_at: Time.new(2018,03,30))
+        challenge.entries <<  build(:entry, user: user1, score: 44, created_at: Time.new(2018,04,01))
+        challenge.entries <<  build(:entry, user: user4, score: 40, created_at: Time.new(2018,04,02))
+        challenge.entries <<  build(:entry, user: user2, score: 38, created_at: Time.new(2018,04,03))
+        challenge.entries <<  build(:entry, user: user2, score: 37, created_at: Time.new(2018,04,04))
+        challenge.entries <<  build(:entry, user: user3, score: 32, created_at: Time.new(2018,04,05))
+        challenge.entries <<  build(:entry, user: user1, score: 29, created_at: Time.new(2018,04,06))
+        challenge.entries <<  build(:entry, user: user4, score: 27, created_at: Time.new(2018,04,07))
+        challenge.entries <<  build(:entry, user: user3, score: 22, created_at: Time.new(2018,04,11))
+      end
+
+      it 'returns the three entries by the test user, with appropriate rankings' do
+        result = RepositoryChallenge.submissions_per_player(challenge.id, user1.id).to_a
+        expect(result.length).to eq(3)
+
+        entry = result[0]
+        expect(entry['user_id']).to eq(user1.id)
+        expect(entry['min_score']).to eq(29)
+        expect(entry['position']).to eq(3)
+        expect(entry['created_at']).to eq(Time.new(2018,04,06))
+
+        entry = result[1]
+        expect(entry['user_id']).to eq(user1.id)
+        expect(entry['min_score']).to eq(44)
+        expect(entry['position']).to eq(5) # >4
+        expect(entry['created_at']).to eq(Time.new(2018,04,01))
+
+        entry = result[2]
+        expect(entry['user_id']).to eq(user1.id)
+        expect(entry['min_score']).to eq(52)
+        expect(entry['position']).to eq(7) # >5
+        expect(entry['created_at']).to eq(Time.new(2018,03,27))
+      end
+    end
+
+  end
 end

--- a/spec/services/submissions_per_user_spec.rb
+++ b/spec/services/submissions_per_user_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe SubmissionsPerUser do
+
+  describe 'All submissions by testuser' do
+    context 'multiple entries' do
+      let(:user1) { create(:user) }
+      let(:user2) { create(:user) }
+      let(:user3) { create(:user) }
+      let(:user4) { create(:user) }
+      let(:user5) { create(:user) }
+      let(:challenge) { create(:challenge, user: user3) }
+
+      before do
+        challenge.entries <<  build(:entry, user: user1, score: 52, created_at: Time.new(2018,03,27))
+        challenge.entries <<  build(:entry, user: user5, score: 51, created_at: Time.new(2018,03,28))
+        challenge.entries <<  build(:entry, user: user2, score: 49, created_at: Time.new(2018,03,29))
+        challenge.entries <<  build(:entry, user: user3, score: 45, created_at: Time.new(2018,03,30))
+        challenge.entries <<  build(:entry, user: user1, score: 44, created_at: Time.new(2018,04,01))
+        challenge.entries <<  build(:entry, user: user4, score: 40, created_at: Time.new(2018,04,02))
+        challenge.entries <<  build(:entry, user: user2, score: 38, created_at: Time.new(2018,04,03))
+        challenge.entries <<  build(:entry, user: user2, score: 37, created_at: Time.new(2018,04,04))
+        challenge.entries <<  build(:entry, user: user3, score: 32, created_at: Time.new(2018,04,05))
+        challenge.entries <<  build(:entry, user: user1, score: 29, created_at: Time.new(2018,04,06))
+        challenge.entries <<  build(:entry, user: user4, score: 27, created_at: Time.new(2018,04,07))
+        challenge.entries <<  build(:entry, user: user3, score: 22, created_at: Time.new(2018,04,11))
+      end
+
+      it 'shows all submission by the user itself' do
+        result = []
+        SubmissionsPerUser.new(user1, challenge.id, user1).each {|e| result.push(e)}
+
+        entry = result[0]
+        expect(entry.user).to eq(user1)
+        expect(entry.score).to eq(29)
+        expect(entry.position).to eq(3)
+
+        entry = result[1]
+        expect(entry.user).to eq(user1)
+        expect(entry.score).to eq(44)
+        expect(entry.position).to eq(">4")
+
+        entry = result[2]
+        expect(entry.user).to eq(user1)
+        expect(entry.score).to eq(52)
+        expect(entry.position).to eq(">5")
+      end
+
+      it 'only show submissions if you have enough score' do
+        result = []
+        SubmissionsPerUser.new(user5, challenge.id, user1).each {|e| result.push(e)}
+
+        # Best score for user5 is 51, so solutions with scores 44 and 29 are hidden.
+        entry = result[0]
+        expect(entry.user).to eq(user1)
+        expect(entry.score).to eq(52)
+        expect(entry.position).to eq(">5")
+      end
+
+      it 'shows correct number of remaining entries' do
+        spu = SubmissionsPerUser.new(user5, challenge.id, user1)
+
+        # Best score for user5 is 51, so solutions with scores 44 and 29 are hidden.
+        # That means there are 2 remaining solutions to unlock.
+        expect(spu.count_remaining).to eq(2)
+      end
+
+      it 'only includes the player in users mapping' do
+        spu = SubmissionsPerUser.new(user5, challenge.id, user1)
+        expect(spu.users).to eq({user1.id => user1})
+      end
+
+      it 'shows the correct owner for a challenge' do
+        spu = SubmissionsPerUser.new(user5, challenge.id, user1)
+        expect(spu.user_id).to eq(user3.id)
+      end
+
+      it 'should not highlight the owner' do
+        spu = SubmissionsPerUser.new(user5, challenge.id, user1)
+        expect(spu.highlight_owner?).to eq(false)
+      end
+
+      it 'counts users correctly' do
+        spu = SubmissionsPerUser.new(user5, challenge.id, user1)
+        expect(spu.count_uniq_users).to eq(5)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This implements #271. It borrows from some ideas from #272 (cc @Hettomei), mainly the URL route, controller and the SubmissionsPerUser class. But it uses a fairly rich and complex Mongo query, in order to get the ranking of the best entry and the "would-be" ranking of the other antries. It also adds links to the per-user page from different places.