### PR TITLE
Use `gem install` to install the version of bundler we need.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - ls -l /home/travis/.rvm/gems # Future reference, targets for quick build
     - cd `dirname $BUNDLE_GEMFILE`
     - pwd # For debug info
-    - gem update bundler # Travis's Bundler 1.7.6 is causing problems
+    - gem install -v 1.16.2 bundler # Travis's Bundler 1.7.6 is causing problems
 script: bundle exec rake
 addons:
   apt:


### PR DESCRIPTION
This fixes Travis-CI checks for Vimgolf PRs.

The `gem update` call probably didn't work as expected because the pre-installed version of bundler was installed as a system gem.

In any case, using `gem install` with an explicit version seems to have fixed the issue.

Tested: https://travis-ci.org/github/filbranden/vimgolf/builds/716451137