### PR TITLE
Allow Mongo Aggregation to use disk for temporary space.

### DIFF
--- a/app/repositories/repository_challenge.rb
+++ b/app/repositories/repository_challenge.rb
@@ -18,7 +18,7 @@ module RepositoryChallenge
   # RepositoryChallenge.collection_aggregate({"$count": 'challenge_count'}).to_a
   # => [{"challenge_count"=>102}]
   def self.collection_aggregate(*args)
-    Challenge.collection.aggregate(args.flatten)
+    Challenge.collection.aggregate(args.flatten).allow_disk_use(true)
   end
 
   # Sum every entries of every Challenge


### PR DESCRIPTION
Aggregations are limited to 100MiB otherwise.

Some of the ranking aggregations using `includeArrayIndex` exceed this limit when looking at a challenge with many entries, so we should allow disk usage to be able to overcome it.