### PR TITLE
Split VERSION into CLI_VERSION (for the Gem) and PROTOCOL_VERSION.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/vimgolf
   specs:
-    vimgolf (0.4.8)
+    vimgolf (0.5.0)
       highline (~> 1.7, >= 1.7.10)
       json_pure (~> 2.1, >= 2.1.0)
       thor (~> 0.14, >= 0.14.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: lib/vimgolf
   specs:
     vimgolf (0.5.0)
-      highline (~> 1.7, >= 1.7.10)
-      json_pure (~> 2.1, >= 2.1.0)
-      thor (~> 0.14, >= 0.14.6)
+      highline (~> 2.0, >= 2.0.3)
+      json_pure (~> 2.3, >= 2.3.1)
+      thor (~> 1.0, >= 1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -81,11 +81,11 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
-    highline (1.7.10)
+    highline (2.0.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    json_pure (2.1.0)
+    json_pure (2.3.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -226,7 +226,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    thor (0.20.0)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tweet-button (0.1.0)

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -102,7 +102,7 @@ class ChallengesController < ApplicationController
         'data' => challenge.output,
         'type' => challenge.output_type
       },
-      'client' => Vimgolf::VERSION
+      'client' => Vimgolf::PROTOCOL_VERSION
     }
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
   <div id="footer" class="container_12 clearfix">
     <div id="copy">
         <%= link_to "Changelog, Rules & FAQ", about_path %>, &nbsp;&nbsp;
-        CLI Version: <b><a href="https://github.com/igrigorik/vimgolf"><%= Vimgolf::VERSION %></a></b>, &nbsp;&nbsp;
+        CLI Version: <b><a href="https://github.com/igrigorik/vimgolf"><%= Vimgolf::CLI_VERSION %></a></b>, &nbsp;&nbsp;
         <a href="https://github.com/igrigorik/vimgolf/">Contribute on GitHub</a>
     </div>
   </div>

--- a/lib/vimgolf/lib/vimgolf/challenge.rb
+++ b/lib/vimgolf/lib/vimgolf/challenge.rb
@@ -50,8 +50,8 @@ module VimGolf
         if !@data.is_a? Hash
           raise
 
-        elsif @data['client'] != Vimgolf::VERSION
-          VimGolf.ui.error "Client version mismatch. Installed: #{Vimgolf::VERSION}, Required: #{@data['client']}."
+        elsif @data['client'] != Vimgolf::PROTOCOL_VERSION
+          VimGolf.ui.error "Client version mismatch. Installed: protocol #{Vimgolf::PROTOCOL_VERSION} (client #{Vimgolf::CLI_VERSION}), Required: #{@data['client']}."
           VimGolf.ui.error "\t gem install vimgolf"
           raise "Bad Version"
         end

--- a/lib/vimgolf/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/lib/vimgolf/cli.rb
@@ -32,6 +32,15 @@ module VimGolf
       super
     end
 
+    desc "version", "print version of Vimgolf client"
+    long_desc <<-DESC
+    Print version of the Vimgolf client.
+    DESC
+
+    def version
+      VimGolf.ui.info "Client #{Vimgolf::CLI_VERSION} (protocol #{Vimgolf::PROTOCOL_VERSION})"
+    end
+
     desc "setup", "configure your VimGolf credentials"
     long_desc <<-DESC
     To participate in the challenge please go to vimgolf.com and register an

--- a/lib/vimgolf/lib/vimgolf/version.rb
+++ b/lib/vimgolf/lib/vimgolf/version.rb
@@ -1,3 +1,4 @@
 module Vimgolf
-  VERSION = "0.4.8"
+  CLI_VERSION = "0.5.0"
+  PROTOCOL_VERSION = "0.4.8"
 end

--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "vimgolf"
 
-  s.add_runtime_dependency "thor", "~> 0.14", ">= 0.14.6"
-  s.add_runtime_dependency "json_pure", "~> 2.1", ">= 2.1.0"
-  s.add_runtime_dependency "highline", "~> 1.7", ">= 1.7.10"
+  s.add_runtime_dependency "thor", "~> 1.0", ">= 1.0.1"
+  s.add_runtime_dependency "json_pure", "~> 2.3", ">= 2.3.1"
+  s.add_runtime_dependency "highline", "~> 2.0", ">= 2.0.3"
 
   s.add_development_dependency "rspec", "~> 3.7", ">= 3.7.0"
   s.add_development_dependency "rake", "~> 12.3", ">= 12.3.1"

--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -4,7 +4,7 @@ require "vimgolf/version"
 
 Gem::Specification.new do |s|
   s.name        = "vimgolf"
-  s.version     = Vimgolf::VERSION
+  s.version     = Vimgolf::CLI_VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Ilya Grigorik"]
   s.email       = ["ilya@igvita.com"]
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
    s.post_install_message = %{
 ------------------------------------------------------------------------------
-Thank you for installing vimgolf-#{Vimgolf::VERSION}.
+Thank you for installing vimgolf-#{Vimgolf::CLI_VERSION}.
 
 0.1.3: custom vimgolf .vimrc file to help level the playing field
 0.2.0: proxy support, custom diffs + proper vimscript parser/scoring

--- a/spec/controllers/challenges_controller_spec.rb
+++ b/spec/controllers/challenges_controller_spec.rb
@@ -38,7 +38,7 @@ describe ChallengesController do
         expect(json).to eq({
           "in"=>{"data"=>"baz", "type"=>"baz_type"},
           "out"=>{"data"=>"qux", "type"=>"qux_type"},
-          "client"=> Vimgolf::VERSION
+          "client"=> Vimgolf::PROTOCOL_VERSION
         })
       end
     end


### PR DESCRIPTION
This way it is possible to release a new client Gem without having to upgrade the server to match the new client. (Fix for #267)

Also update Gem dependencies of the client to latest version (at least to solve a deprecation warning in older highlinec

Add a new `vimgolf version` subcommand.