### PR TITLE
Bump up client version to 0.4.9, update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: lib/vimgolf
   specs:
     vimgolf (0.4.9)
-      highline (~> 1.7, >= 1.7.10)
-      json_pure (~> 2.1, >= 2.1.0)
-      thor (~> 0.14, >= 0.14.6)
+      highline (~> 2.0, >= 2.0.3)
+      json_pure (~> 2.3, >= 2.3.1)
+      thor (~> 1.0, >= 1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -81,11 +81,11 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
-    highline (1.7.10)
+    highline (2.0.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    json_pure (2.1.0)
+    json_pure (2.5.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -226,7 +226,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    thor (0.20.0)
+    thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tweet-button (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/vimgolf
   specs:
-    vimgolf (0.4.8)
+    vimgolf (0.4.9)
       highline (~> 1.7, >= 1.7.10)
       json_pure (~> 2.1, >= 2.1.0)
       thor (~> 0.14, >= 0.14.6)

--- a/lib/vimgolf/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/lib/vimgolf/cli.rb
@@ -32,6 +32,15 @@ module VimGolf
       super
     end
 
+    desc "version", "print version of Vimgolf client"
+    long_desc <<-DESC
+    Print version of the Vimgolf client.
+    DESC
+
+    def version
+      VimGolf.ui.info "Client #{Vimgolf::VERSION}"
+    end
+
     desc "setup", "configure your VimGolf credentials"
     long_desc <<-DESC
     To participate in the challenge please go to vimgolf.com and register an

--- a/lib/vimgolf/lib/vimgolf/version.rb
+++ b/lib/vimgolf/lib/vimgolf/version.rb
@@ -1,3 +1,3 @@
 module Vimgolf
-  VERSION = "0.4.8"
+  VERSION = "0.4.9"
 end

--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "vimgolf"
 
-  s.add_runtime_dependency "thor", "~> 0.14", ">= 0.14.6"
-  s.add_runtime_dependency "json_pure", "~> 2.1", ">= 2.1.0"
-  s.add_runtime_dependency "highline", "~> 1.7", ">= 1.7.10"
+  s.add_runtime_dependency "thor", "~> 1.0", ">= 1.0.1"
+  s.add_runtime_dependency "json_pure", "~> 2.3", ">= 2.3.1"
+  s.add_runtime_dependency "highline", "~> 2.0", ">= 2.0.3"
 
   s.add_development_dependency "rspec", "~> 3.7", ">= 3.7.0"
   s.add_development_dependency "rake", "~> 12.3", ">= 12.3.1"


### PR DESCRIPTION
This is an alternative to #301.

Fixes #267. There have been quite a few important commits that affect the client side and haven't been released.

Also update Gem dependencies of the client to latest version (at least to solve a deprecation warning in older highline.

Add a new `vimgolf version` subcommand.

**NOTE:** The current model requires server and client to be in sync, so the Ruby gem should be published just before and around the same time as the server is updated to require version 0.4.9.

Installing this gem and running it against the current server setup fails with:

```
$ vimgolf put 60340000c06738000924d803
Downloading Vimgolf challenge: 60340000c06738000924d803
Client version mismatch. Installed: 0.4.9, Required: 0.4.8.
	 gem install vimgolf
```

I guess this is expected, as having the server require a specific client is a good way to ensure clients are running the latest version. (Even though in this particular case the changes in the client do not introduce incompatibility with the server.)
