### PR TITLE
Change docker image to have an up to date vim and gem version

### DIFF
--- a/app/views/main/about.erb
+++ b/app/views/main/about.erb
@@ -65,8 +65,8 @@
     <ul>
         <li><b>Golfing through a proxy:</b> set your "<b>http_proxy</b>" environment variable to URL of proxy</li>
         <li><b>Custom diff's &amp; flags:</b> set your "<b>DIFF</b>" environment variable (<a href="https://github.com/igrigorik/vimgolf/commit/d69469a93b404c4358b23fc1c4c7556a9563577e">d6946</a>)</li>
-        <li><b>Golfing without ruby installation:</b> <a href="https://hub.docker.com/r/kramos/vimgolf/">use docker</a><br />
-          <code>docker run --rm -it -e "key=[YOUR_VIMGOLF_KEY]" kramos/vimgolf [challenge ID]</code>
+        <li><b>Golfing without ruby installation:</b> <a href="https://hub.docker.com/r/hettomei/vimgolf/">use docker</a><br />
+          <code>docker run --rm -it -e "key=YOUR_VIMGOLF_KEY" hettomei/vimgolf challenge_ID</code>
         </li>
 
 


### PR DESCRIPTION
Maybe I should have asked to https://github.com/kramos/vimgolf to update the container ?

image : https://hub.docker.com/r/hettomei/vimgolf/

source : https://github.com/Hettomei/docker-vimgolf