### PR TITLE
Disable asset compile in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Vimgolf::Application.configure do
   config.assets.compress = true
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Generate digests for asset URLs
   config.assets.digest = true


### PR DESCRIPTION
Pushing to Heroku produces this warning:

```
remote: ###### WARNING:
remote:
remote:        You set your `config.assets.compile = true` in production.
remote:        This can negatively impact the performance of your application.
remote:
remote:        For more information can be found in this article:
remote:          https://devcenter.heroku.com/articles/rails-asset-pipeline#compile-set-to-true-in-production
```

Let's disable asset compile in production, instead using precompile assets on deploy, which is the default.

I just tested pushing this to https://vimgolf-staging.herokuapp.com/ and, as far as I can tell, everything is working as exepcted.

cc @igrigorik @Hettomei 
