### PR TITLE
Switch Avatar to use an Identicon while Twitter profile pics are unavailable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def twitter_avatar(user)
-    "<img src='https://avatars.io/twitter/#{user}/small' class='user'>".html_safe
+    "<img src='http://identicon-1132.appspot.com/#{Digest::MD5.hexdigest(user)}' class='user'>".html_safe
   end
 
   def current_url


### PR DESCRIPTION
Switch Avatar to use an Identicon while Twitter profile pics are unavailable.

I found this service which provides a consistent identicon based on the passed information. Pass it an MD5 digest of the username as the unique information.

The Identicons are not as good as an actual profile picture... But they're definitely better than serving a broken image (or removing the avatars altogether.)

This is a workaround for #316 until we have a better solution for it.

cc @Hettomei 
