### PR TITLE
Switch to using Challenge#top_entries instead of Mongo queries.

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -23,7 +23,7 @@ class Challenge
   validates_length_of :diff, minimum: 1, maximum: MAX_FILESIZE
 
   def top_entries
-    entries.top_by_user
+    @top_entries ||= entries.top_by_user
   end
 
   def participator?(current_user)

--- a/app/repositories/repository_challenge.rb
+++ b/app/repositories/repository_challenge.rb
@@ -247,12 +247,14 @@ module RepositoryChallenge
   # RepositoryChallenge.best_player_score(challenge_id, user_id).to_a
   # => 123
   def self.best_player_score(challenge_id, player_id)
-    result = collection_aggregate(
-      best_score_per_user(challenge_id),
-      { "$match": { "user_id": player_id } },
-      { "$limit": 1 },
-    ).first
-    result && result['min_score']
+    Challenge
+      .find(challenge_id)
+      .top_entries
+      .select { |e| e.user_id == player_id }
+      .first
+      .score
+  rescue StandardError
+    nil
   end
 
   def self.submissions(challenge_id:, min_score:, per_page:, page:)

--- a/app/repositories/repository_challenge.rb
+++ b/app/repositories/repository_challenge.rb
@@ -231,13 +231,14 @@ module RepositoryChallenge
   # RepositoryChallenge.bellow_score(challenge_id, 10)
   # => 2 # not 9, because the visible solution for B is 2
   def self.bellow_score(challenge_id, score)
-    result = collection_aggregate(
-      best_score_per_user(challenge_id),
-      { "$match": { "min_score": { "$lt": score } } },
-      { "$sort": { "min_score": -1 } },
-      { "$limit": 1 },
-    ).first
-    result && result['min_score'] || 0
+    Challenge
+      .find(challenge_id)
+      .top_entries
+      .select { |e| e.score < score }
+      .last
+      .score
+  rescue StandardError
+    0
   end
 
   # Return the best score for a given user_id

--- a/app/services/solution.rb
+++ b/app/services/solution.rb
@@ -8,11 +8,11 @@ class Solution
   attr_reader :solution, :position
 
   def id
-    solution[:entry_id]
+    solution[:id]
   end
 
   def score
-    solution[:min_score]
+    solution[:score]
   end
 
   def script

--- a/app/views/challenges/show.erb
+++ b/app/views/challenges/show.erb
@@ -39,7 +39,7 @@
         <% @leaderboard.each do |entry, user, position| %>
             <div class="notice clearfix">
                 <%= twitter_avatar user.nickname %>
-                <div style="float:right; text-align:center;font-size:2.4em"><b><%= link_to entry[:min_score],
+                <div style="float:right; text-align:center;font-size:2.4em"><b><%= link_to entry[:score],
                   user_challenge_path(@show_challenge.id, user.nickname) %></b></div>
 
                 <h6 style="margin-bottom:0">

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -96,7 +96,7 @@ describe RepositoryChallenge do
 
         expect(result.length).to eq(1)
 
-        expect(result.first['min_score']).to eq(7)
+        expect(result.first['score']).to eq(7)
         expect(result.first['created_at']).to eq(Time.new(2018,04,28))
       end
     end
@@ -120,7 +120,7 @@ describe RepositoryChallenge do
         ).to_a
         expect(result.length).to eq(1)
 
-        expect(result.first['min_score']).to eq(7)
+        expect(result.first['score']).to eq(7)
         expect(result.first['created_at']).to eq(Time.new(2017))
       end
     end
@@ -156,15 +156,15 @@ describe RepositoryChallenge do
 
         expect(result.length).to eq(3)
 
-        expect(result.first['min_score']).to eq(6)
+        expect(result.first['score']).to eq(6)
         expect(result.first['user_id']).to eq(best_user.id)
         expect(result.first['created_at']).to eq(Time.new(2019))
 
-        expect(result.second['min_score']).to eq(7)
+        expect(result.second['score']).to eq(7)
         expect(result.second['user_id']).to eq(user2.id)
         expect(result.second['created_at']).to eq(Time.new(2016))
 
-        expect(result.last['min_score']).to eq(7)
+        expect(result.last['score']).to eq(7)
         expect(result.last['user_id']).to eq(user1.id)
         expect(result.last['created_at']).to eq(Time.new(2017))
       end
@@ -509,19 +509,19 @@ describe RepositoryChallenge do
 
         entry = result[0]
         expect(entry['user_id']).to eq(user1.id)
-        expect(entry['min_score']).to eq(29)
+        expect(entry['score']).to eq(29)
         expect(entry['position']).to eq(3)
         expect(entry['created_at']).to eq(Time.new(2018,04,06))
 
         entry = result[1]
         expect(entry['user_id']).to eq(user1.id)
-        expect(entry['min_score']).to eq(44)
+        expect(entry['score']).to eq(44)
         expect(entry['position']).to eq(5) # >4
         expect(entry['created_at']).to eq(Time.new(2018,04,01))
 
         entry = result[2]
         expect(entry['user_id']).to eq(user1.id)
-        expect(entry['min_score']).to eq(52)
+        expect(entry['score']).to eq(52)
         expect(entry['position']).to eq(7) # >5
         expect(entry['created_at']).to eq(Time.new(2018,03,27))
       end


### PR DESCRIPTION
Switch to using Challenge#top_entries instead of Mongo queries.

MongoDB queries were hitting sorting limits and disk use for sorting isn't available in the MongoDB Atlas tier we're using.

So let's switch to just accessing Challenge#top_entries and do the filtering in Ruby code. This is a little bit slower, but it should work just fine for reasonably sized challenges. In my testing, I had trouble with a 37,000 entry challenge (request exceeded 15,000ms) but up to ~30,000 entries it should work fine.

This should help fix #307.

This is now deployed to https://vimgolf-staging.herokuapp.com/ (but for some reason it's timing out there, I need to take a closer look at what's happening there.)

cc @Hettomei 
