### PR TITLE
Downgrade mongoid + mongo + bson gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ ruby '2.6.7'
 
 gem 'rails', '~> 5.2.0'
 
-gem 'mongo'
-gem 'bson'
-gem 'mongoid', '~> 6.0'
+gem 'mongo', '~> 2.5.0'
+gem 'bson', '~> 4.3.0'
+gem 'mongoid', '~> 6.1.0'
 
 gem 'json'
 gem 'memcachier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     ast (2.4.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bson (4.12.0)
+    bson (4.3.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.35.3)
@@ -121,11 +121,11 @@ GEM
     mini_racer (0.4.0)
       libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
-    mongo (2.14.0)
-      bson (>= 4.8.2, < 5.0.0)
-    mongoid (6.4.8)
-      activemodel (>= 5.1, < 6.0.0)
-      mongo (>= 2.5.1, < 3.0.0)
+    mongo (2.5.3)
+      bson (>= 4.3.0, < 5.0.0)
+    mongoid (6.1.1)
+      activemodel (~> 5.0)
+      mongo (>= 2.4.1, < 3.0.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.3)
@@ -289,7 +289,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bson
+  bson (~> 4.3.0)
   capybara
   codeclimate-test-reporter (~> 1.0.0)
   dalli
@@ -301,8 +301,8 @@ DEPENDENCIES
   launchy
   memcachier
   mini_racer
-  mongo
-  mongoid (~> 6.0)
+  mongo (~> 2.5.0)
+  mongoid (~> 6.1.0)
   newrelic_rpm
   omniauth (~> 2.0)
   omniauth-rails_csrf_protection (~> 1.0)


### PR DESCRIPTION
The versions after the Ruby 2.6 upgrade started to choke on data from specific entries in challenges, failing UTF-8 validation. The entries in question have special characters such as '\x80' and '\xFF', so that's not completely surprising.

The older versions of the gems work fine with that data, so let's downgrade them in order to make the challenges accessible again.

Fixes #319.

Sample fixed challenge from staging:
https://vimgolf-staging.herokuapp.com/challenges/51a388ac06f7d20002000006

cc @Hettomei 
