### PR TITLE
Update README to reflect new development backend on Active Record

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,22 +4,110 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 #
-default: &default
+default_sqlite: &default_sqlite
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
-development:
-  <<: *default
+development_sqlite: &development_sqlite
+  <<: *default_sqlite
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
-test:
-  <<: *default
+test_sqlite: &test_sqlite
+  <<: *default_sqlite
   database: db/test.sqlite3
 
+# PostgreSQL. Versions 9.3 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
+#
+default_pg: &default_pg
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+development_pg: &development_pg
+  <<: *default_pg
+  database: vimgolf_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: vimgolf
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test_pg: &test_pg
+  <<: *default_pg
+  database: vimgolf_test
+
+# Switch development/test between sqlite and pg based on
+# $DATABASE_ADAPTER environment variable.
+development:
+  <<: <%= ENV['DATABASE_ADAPTER'] == 'pg' ? '*development_pg' : '*development_sqlite' %>
+
+test:
+  <<: <%= ENV['DATABASE_ADAPTER'] == 'pg' ? '*test_pg' : '*test_sqlite' %>
+
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
 production:
-  <<: *default
-  database: db/production.sqlite3
+  <<: *default_pg
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,5 +26,9 @@ Vimgolf::Application.configure do
   config.assets.debug = true
 
   config.eager_load = false
-end
 
+  # Do not dump db/schema.rb when using Postgres.
+  # The format is different from the one used by SQLite3,
+  # so let's ignore the schema while running a migration on it.
+  config.active_record.dump_schema_after_migration = false if ENV['DATABASE_ADAPTER'] == 'pg'
+end


### PR DESCRIPTION
I dropped the instructions regarding MongoDB and added the instructions for SQLite3 and Postgres.

Also rephrased or clarified parts of the README that I thought could benefit from it.

I updated `database.yml` to include both SQLite3 and Postgres setups for development + test and use an environment variable (`DATABASE_ADAPTER=pg`) to select using Postgres in development. Also disabled dumping schema to `db/schema.rb` when Postgres is in use, as the formats seem to be somewhat incompatible. These are all reflected in the documentation.

Feel free to take it for a spin and comment or rephrase anything you'd like to have changed.

/cc @Hettomei 
