### PR TITLE
Include position in ranking for each challenge in user page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,13 +18,24 @@ class User < ActiveRecord::Base
 
   def player_best_scores
     Entry.from(
-      Entry.where(user_id: id).select(
-        '*',
-        'row_number() OVER (PARTITION BY challenge_id ORDER BY score, created_at) as challenge_ranked_entry'
-      ),
+      Entry.from(
+        Entry
+        .where(challenge_id: User.find(id).entries.select(:challenge_id))
+        .select(
+          '*',
+          'row_number() OVER (PARTITION BY challenge_id, user_id ORDER BY score, created_at) AS user_ranked_entry'
+        ),
+        :entries
+      )
+        .where(user_ranked_entry: 1)
+        .select(
+          '*',
+          'row_number() OVER (PARTITION BY challenge_id ORDER BY score, created_at) AS position'
+        ),
       :entries
     )
-         .where(challenge_ranked_entry: 1)
+         .where(user_id: id)
+         .select('*', 'position')
          .order('challenge_id DESC')
   end
 end

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -8,7 +8,7 @@
               <li>Best score: <b><%= entry.challenge.best_score %></b></li>
               <li>Best player score: <b><%= entry.score %></b></li>
             <% if @show_profile.show_ranking %>
-              <li>Position: <b>#<%= player_challenge['position'] %> / <%= player_challenge['count_golfers'] %></b></li>
+              <li>Position: <b>#<%= entry.position %> / <%= entry.challenge.count_uniq_users %></b></li>
             <% end %>
               <li>Number of attempts: <b><%= link_to entry.challenge.count_entries_by(@show_profile.player.id),
                 user_challenge_path(entry.challenge.urlkey, @show_profile.nickname) %></b></li>

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -338,8 +338,7 @@ describe RepositoryChallenge do
       end
     end
 
-    # Disable, player_best_score(..., true) not implemented.
-    xcontext 'when player has submitted two entries to a challenge' do
+    context 'when player has submitted two entries to a challenge' do
       let(:user) { create(:user) }
       let(:user2) { create(:user) }
       let(:challenge1) { create(:challenge) }
@@ -351,22 +350,22 @@ describe RepositoryChallenge do
       end
 
       it 'return expected user information about the user' do
-        result = RepositoryChallenge.player_best_scores(user.id, true).to_a
-        expect(result.length).to eq(1)
-        challenge = result.first
+        result = RepositoryChallenge.player_best_scores(user.id, true)
+        expect(result.size).to eq(1)
+        entry = result.first
+        challenge = entry.challenge
         expect(challenge['id']).to eq(challenge1.id)
         expect(challenge['title']).to eq(challenge1.title)
         expect(challenge['description']).to eq(challenge1.description)
-        expect(challenge['count_entries']).to eq(3)
-        expect(challenge['best_score']).to eq(10)
-        expect(challenge['best_player_score']).to eq(12)
-        expect(challenge['attempts']).to eq(2)
-        expect(challenge['position']).to eq(2)
+        expect(challenge.count_entries).to eq(3)
+        expect(challenge.best_score).to eq(10)
+        expect(entry.score).to eq(12)
+        expect(challenge.count_entries_by(entry.user_id)).to eq(2)
+        expect(entry['position']).to eq(2)
       end
     end
 
-    # Disable, player_best_score(..., true) not implemented.
-    xcontext 'when player has submitted entries to multiple challenges' do
+    context 'when player has submitted entries to multiple challenges' do
       let(:user) { create(:user) }
       let(:user2) { create(:user) }
       let(:challenge1) { create(:challenge, user: user, created_at: Time.new(2017)) }
@@ -380,37 +379,39 @@ describe RepositoryChallenge do
       end
 
       it 'return expected user information about the user' do
-        result = RepositoryChallenge.player_best_scores(user.id, true).to_a
-        expect(result.length).to eq(2)
+        result = RepositoryChallenge.player_best_scores(user.id, true)
+        expect(result.size).to eq(2)
 
         # Ensure challenges are in chronological order, challenge2 is first.
-        challenge = result[0]
+        entry = result[0]
+        challenge = entry.challenge
         expect(challenge['id']).to eq(challenge2.id)
         expect(challenge['title']).to eq(challenge2.title)
         expect(challenge['description']).to eq(challenge2.description)
-        expect(challenge['count_entries']).to eq(1)
-        expect(challenge['best_score']).to eq(14)
-        expect(challenge['best_player_score']).to eq(14)
-        expect(challenge['attempts']).to eq(1)
-        expect(challenge['position']).to eq(1)
-        expect(challenge['count_golfers']).to eq(1)
+        expect(challenge.count_entries).to eq(1)
+        expect(challenge.best_score).to eq(14)
+        expect(entry.score).to eq(14)
+        expect(challenge.count_entries_by(entry.user_id)).to eq(1)
+        expect(entry['position']).to eq(1)
+        expect(challenge.count_uniq_users).to eq(1)
 
         # And challenge1 is next.
-        challenge = result[1]
+        entry = result[1]
+        challenge = entry.challenge
         expect(challenge['id']).to eq(challenge1.id)
         expect(challenge['title']).to eq(challenge1.title)
         expect(challenge['description']).to eq(challenge1.description)
-        expect(challenge['count_entries']).to eq(3)
-        expect(challenge['best_score']).to eq(10)
-        expect(challenge['best_player_score']).to eq(12)
-        expect(challenge['attempts']).to eq(2)
-        expect(challenge['position']).to eq(2)
-        expect(challenge['count_golfers']).to eq(2)
+        expect(challenge.count_entries).to eq(3)
+        expect(challenge.best_score).to eq(10)
+        expect(entry.score).to eq(12)
+        expect(challenge.count_entries_by(entry.user_id)).to eq(2)
+        expect(entry['position']).to eq(2)
+        expect(challenge.count_uniq_users).to eq(2)
       end
     end
   end
 
-  xdescribe '.submissions_per_player(challenge_id, player_id)' do
+  describe '.submissions_per_player(challenge_id, player_id)' do
     context 'when there are entries in challenge' do
       let(:user1) { create(:user) }
       let(:user2) { create(:user) }
@@ -435,8 +436,8 @@ describe RepositoryChallenge do
       end
 
       it 'returns the three entries by the test user, with appropriate rankings' do
-        result = RepositoryChallenge.submissions_per_player(challenge.id, user1.id).to_a
-        expect(result.length).to eq(3)
+        result = Challenge.find(challenge.id).player_entries(user1.id)
+        expect(result.size).to eq(3)
 
         entry = result[0]
         expect(entry['user_id']).to eq(user1.id)


### PR DESCRIPTION
This reimplements PR #293 on top of ActiveRecord.

Also re-enable the test cases that were temporarily disabled. Two of those were testing for this feature, the third one tested a related feature (showing number of submissions for the same challenge) but it was using a method removed during the ActiveRecord migration.

Tested:

- Accessing a user page with `?ranking=1` displays the position of the best user submission for each challenge.
- Tests under `bundle exec rspec` passing.
- Ran rspec tests against both SQLite3 and Postgres backends, both passed successfully.
