### PR TITLE
Update client to use HTTPS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ jobs:
     - rvm: 2.3 # Test only the cli, on older Ruby.
       dist: xenial
       gemfile: lib/vimgolf/Gemfile
+    - rvm: 2.0 # Test only the cli, on older Ruby.
+      dist: trusty
+      gemfile: lib/vimgolf/Gemfile
 services:
   - mongodb
 before_install:

--- a/lib/vimgolf/lib/vimgolf/challenge.rb
+++ b/lib/vimgolf/lib/vimgolf/challenge.rb
@@ -38,12 +38,7 @@ module VimGolf
     def download
       @remote = true
       begin
-        url = URI.parse("#{GOLFHOST}/challenges/#{@id}.json")
-        req = Net::HTTP::Get.new(url.path)
-
-        proxy_url, proxy_user, proxy_pass = get_proxy
-        proxy = Net::HTTP::Proxy(proxy_url.host, proxy_url.port, proxy_user, proxy_pass)
-        res = proxy.start(url.host, url.port) { |http| http.request(req) }
+        res = Net::HTTP.get_response(URI("#{GOLFHOST}/challenges/#{@id}.json"))
 
         @data = JSON.parse(res.body)
 
@@ -84,23 +79,20 @@ module VimGolf
 
     def upload
       begin
-        url = URI.parse("#{GOLFHOST}/entry.json")
+        res = Net::HTTP.post(
+          URI("#{GOLFHOST}/entry.json"),
+          URI.encode_www_form(
+            "challenge_id" => @id,
+            "apikey" => Config.load['key'],
+            "entry" => IO.binread(log_path)
+          ),
+          "Accept" => "application/json"
+        )
 
-        proxy_url, proxy_user, proxy_pass = get_proxy
-        proxy = Net::HTTP::Proxy(proxy_url.host, proxy_url.port, proxy_user, proxy_pass)
+        res = JSON.parse(res.body)
 
-        proxy.start(url.host, url.port) do |http|
-          request = Net::HTTP::Post.new(url.request_uri)
-          request.set_form_data({"challenge_id" => @id, "apikey" => Config.load['key'], "entry" => IO.binread(log_path)})
-          request["Accept"] = "application/json"
-
-          res = http.request(request)
-          res = JSON.parse(res.body)
-
-          raise if !res.is_a? Hash
-          res['status'].to_sym
-
-        end
+        raise if !res.is_a? Hash
+        res['status'].to_sym
       rescue Exception => e
         debug(e)
         raise "Uh oh, entry upload has failed, please check your key."
@@ -122,20 +114,6 @@ module VimGolf
     end
 
     private
-      def get_proxy
-        begin
-          proxy_url = URI.parse(PROXY)
-        rescue Exception => e
-          VimGolf.ui.error "Invalid proxy uri in http_proxy environment variable - will try to run with out proxy"
-          proxy_url = URI.parse("");
-        end
-
-        proxy_url.port ||= 80
-        proxy_user, proxy_pass = proxy_url.userinfo.split(/:/) if proxy_url.userinfo
-
-        return proxy_url, proxy_user, proxy_pass
-      end
-
       def debug(msg)
         p [caller.first, msg] if GOLFDEBUG
       end

--- a/lib/vimgolf/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/lib/vimgolf/cli.rb
@@ -1,10 +1,9 @@
 module VimGolf
 
   GOLFDEBUG    = ENV['GOLFDEBUG'].to_sym rescue false
-  GOLFHOST     = ENV['GOLFHOST']     || "http://www.vimgolf.com"
+  GOLFHOST     = ENV['GOLFHOST']     || "https://www.vimgolf.com"
   GOLFSHOWDIFF = ENV['GOLFSHOWDIFF'] || 'vim -d -n'
   GOLFVIM      = ENV['GOLFVIM']      || 'vim'
-  PROXY        = ENV['http_proxy']   || ''
 
   class Error
   end

--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.7", ">= 3.7.0"
   s.add_development_dependency "rake", "~> 12.3", ">= 12.3.1"
   s.add_development_dependency "climate_control", "~> 0.2"
+  s.add_development_dependency "rexml", "~> 3.1.9"
   s.add_development_dependency "webmock", "~> 3.13"
 
   s.files         = Dir.glob("{bin,lib}/**/*") + %w(README.md)

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -8,6 +8,12 @@ TESTDATA = File.join(File.dirname(__FILE__), 'testdata')
 MOCK_VIM = File.join(File.dirname(__FILE__), 'mock_bin', 'mock_vim.rb')
 MOCK_DIFF = File.join(File.dirname(__FILE__), 'mock_bin', 'mock_diff.sh')
 
+class String
+  def strip_heredoc
+    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
+  end
+end
+
 describe VimGolf do
   it "provides VimGolf errors" do
     expect(VimGolf::Error).to be
@@ -96,7 +102,7 @@ describe VimGolf do
           )
         end
 
-        expect(out).to include <<~EDQ
+        expect(out).to include <<-EDQ.strip_heredoc
           Here are your keystrokes:
           7<C-A>atest<Home>Bill <Esc>ZZ
 
@@ -127,7 +133,7 @@ describe VimGolf do
           )
         end
 
-        expect(out).to include <<~EDQ
+        expect(out).to include <<-EDQ.strip_heredoc
           Here are your keystrokes:
           7<C-A>atest<Home>Bill <Esc>ZZ
 
@@ -144,7 +150,7 @@ describe VimGolf do
           Thanks for playing!
         EDQ
 
-        expect(File.read(File.join(tmpdir, 'diff-output.txt'))).to include <<~EDQ
+        expect(File.read(File.join(tmpdir, 'diff-output.txt'))).to include <<-EDQ.strip_heredoc
           @@ -1 +1 @@
           -Bill nye  says 010test
           +Naomi nye  says 008testing
@@ -207,7 +213,7 @@ describe VimGolf do
         expect(get_req).to have_been_requested
         expect(post_req).to have_been_requested
 
-        expect(out).to include <<~EDQ
+        expect(out).to include <<-EDQ.strip_heredoc
           Downloading Vimgolf challenge: 8v90deadbeef000012345678
           Launching VimGolf session for challenge: 8v90deadbeef000012345678
 
@@ -263,7 +269,7 @@ describe VimGolf do
 
         expect(get_req).to have_been_requested
 
-        expect(out).to include <<~EDQ
+        expect(out).to include <<-EDQ.strip_heredoc
           Downloading Vimgolf challenge: 8v90deadbeef000012345678
           Client version mismatch. Installed: #{Vimgolf::VERSION}, Required: 0.1.
           \t gem install vimgolf


### PR DESCRIPTION
We don't need to do explicit proxy detection/configuration, since in modern Ruby the `Net::HTTP::new` method will look it up based on the traditional environment variables.

https://ruby-doc.org/stdlib-2.7.3/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new

> If none of the [proxy] arguments are given, the proxy host and port
> are taken from the `http_proxy` environment variable (or its uppercase
> equivalent) if present. If the proxy requires authentication you must
> supply it by hand. See `URI::Generic#find_proxy` for details of proxy
> detection from the environment.

Also switch the default GOLFHOST to use the `https://` URL.

Even though the connection is using `https://`, the proxy used is the one from the `http_proxy` environment variable (if configured.)

Tested by running `mitmdump` from [mitmproxy](https://github.com/mitmproxy/mitmproxy) locally, to inspect the connections going through it.

```
$ http_proxy=http://localhost:8080 bundle exec vimgolf put 9v0060a1b5ed000000000204
```

This actually fails, since Ruby doesn't see the CA certificate used by mitmproxy. The `mitmdump` output logs the following:

```
[::1]:44364: clientconnect
[::1]:44364: CONNECT www.vimgolf.com:443
 << Cannot establish TLS with client (sni: www.vimgolf.com): TlsException("SSL handshake error: Error([('SSL routines', 'ssl3_read_bytes', 'tlsv1 alert unknown ca')])")
[::1]:44364: clientdisconnect
```

To test this locally, it's possible to use another environment variable to override the CA certificate to be recognized:

```
$ SSL_CERT_FILE=~/.mitmproxy/mitmproxy-ca-cert.pem http_proxy=http://localhost:8080 bundle exec vimgolf put 9v0060a1b5ed000000000204
```

This works as expected. `mitmdump` produces the following logs.

```
[::1]:44370: clientconnect
[::1]:44370: GET https://www.vimgolf.com/challenges/9v0060a1b5ed000000000204.json
          << 200 OK 233b
[::1]:44370: clientdisconnect
```

This should address #250 and help address #299 (which after releasing a client with this change is just the matter of flipping the bit on Heroku to do the redirects.)