### PR TITLE
Release new client gem 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 os: linux
 dist: focal
+env:
+  - GOLFHOST=https://vimgolf-staging.herokuapp.com
 jobs:
   include:
     - rvm: 2.6.7 # Test web AND cli with specific version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: lib/vimgolf
   specs:
-    vimgolf (0.4.9)
+    vimgolf (0.5.0)
       highline (~> 2.0, >= 2.0.3)
       json_pure (~> 2.3, >= 2.3.1)
       thor (~> 1.0, >= 1.0.1)

--- a/app/views/main/about.erb
+++ b/app/views/main/about.erb
@@ -2,6 +2,7 @@
 
     <h3><b>Changelog</b> <a href="https://github.com/igrigorik/vimgolf/commits/master">(details)</a></h3>
     <ul>
+        <li><b>May 28, 2021</b>: shipped v0.5.0 with support for HTTPS</li>
         <li><b>May 06, 2021</b>: site performance improvements: migrated from MongoDB Atlas to Active Record on Postgres backend (<a href="https://twitter.com/igrigorik/status/1390690636932599818">charts</a>)</li>
         <li><b>Apr 07, 2021</b>: switched avatars to identicons, since Twitter profile pictures are no longer accessible by an easy URL (need better fix)</li>
         <li><b>Mar 26, 2021</b>: upgraded to Rails 5.2 under Ruby 2.6, using heroku-20 platform</li>

--- a/lib/vimgolf/lib/vimgolf/version.rb
+++ b/lib/vimgolf/lib/vimgolf/version.rb
@@ -1,3 +1,3 @@
 module Vimgolf
-  VERSION = "0.4.9"
+  VERSION = "0.5.0"
 end

--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "vimgolf"
 
+  s.required_ruby_version = ">= 2.0"
+
   s.add_runtime_dependency "thor", "~> 1.0", ">= 1.0.1"
   s.add_runtime_dependency "json_pure", "~> 2.3", ">= 2.3.1"
   s.add_runtime_dependency "highline", "~> 2.0", ">= 2.0.3"


### PR DESCRIPTION
This includes the Net::HTTP changes to use https by default.

Also add explicit requirement on Ruby >= 2.0 for the client gem.

We have one test that hits (actual!) production, so in order to work with it set GOLFHOST to point to the staging environment. I pushed this version to the staging environment already, so the test should work with it.

I already added a changelog entry for this Friday, I'm expecting to push the new version on that date...
