### PR TITLE
Add configuration for CI on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: Vimgolf CI
+on:
+  - push
+  - pull_request
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out git tree
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run rubocop
+        run: bundle exec rubocop
+
+  rspec-rails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out git tree
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run RSpec tests
+        run: bundle exec rake
+      - name: Upload coverage information
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./coverage/coverage.xml
+
+  rspec-rails-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Check out git tree
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run RSpec tests
+        run: bundle exec rake
+
+  rspec-rails-pg:
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: vimgolfgh
+          POSTGRES_PASSWORD: vimgolfpw
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_ADAPTER: pg
+      DATABASE_URL: postgresql://vimgolfgh:vimgolfpw@localhost/
+    steps:
+      - name: Check out git tree
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Create database
+        run: bundle exec rails db:create db:migrate RAILS_ENV=test
+      - name: Run RSpec tests
+        run: bundle exec rake
+
+  rspec-client-gem:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        ruby-version:
+          - '2.3.8'
+          - '2.4.10'
+          - '2.7.3'
+          - '3.0.1'
+        include:
+          - os: ubuntu-latest
+            ruby-version: '2.1.9'
+          - os: windows-latest
+            ruby-version: '2.7.3'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out git tree
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+        env:
+          BUNDLE_GEMFILE: lib/vimgolf/Gemfile
+      - name: Run RSpec tests
+        working-directory: lib/vimgolf
+        run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test, :development do
   gem 'capybara'
   gem 'climate_control'
   gem 'cuprite'
+  gem 'diff-lcs', require: false
   gem 'execjs'
   gem 'mini_racer'
   gem 'launchy'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,8 @@ group :test, :development do
   gem 'rspec-rails', '~> 4.0'
   gem 'rails-controller-testing'
   gem 'shoulda-matchers'
-  gem 'simplecov', :require => false
+  gem 'simplecov', require: false
+  gem 'simplecov-cobertura', require: false
   gem 'codeclimate-test-reporter', '~> 1.0.0'
   gem 'capybara'
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,8 @@ GEM
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-cobertura (1.4.2)
+      simplecov (~> 0.8)
     simplecov-html (0.10.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -344,6 +346,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov
+  simplecov-cobertura
   sprockets-rails (~> 2.0)
   sqlite3 (~> 1.3.6)
   tweet-button

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,7 @@ DEPENDENCIES
   codeclimate-test-reporter (~> 1.0.0)
   cuprite
   dalli
+  diff-lcs
   execjs
   factory_bot (~> 4.0)
   faker

--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.7", ">= 3.7.0"
   s.add_development_dependency "rake", "~> 12.3", ">= 12.3.1"
   s.add_development_dependency "climate_control", "~> 0.2"
+  s.add_development_dependency "diff-lcs", "~> 1.4"
   s.add_development_dependency "rexml", "~> 3.1.9"
   s.add_development_dependency "webmock", "~> 3.13"
 

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -6,7 +6,7 @@ WebMock.disable_net_connect!
 
 TESTDATA = File.join(File.dirname(__FILE__), 'testdata')
 MOCK_VIM = File.join(File.dirname(__FILE__), 'mock_bin', 'mock_vim.rb')
-MOCK_DIFF = File.join(File.dirname(__FILE__), 'mock_bin', 'mock_diff.sh')
+MOCK_DIFF = File.join(File.dirname(__FILE__), 'mock_bin', 'mock_diff.rb')
 
 class String
   def strip_heredoc
@@ -117,7 +117,7 @@ describe VimGolf do
       ClimateControl.modify HOME: tmpdir do
         VimGolf::CLI.initialize_ui
         stub_const('VimGolf::CLI::GOLFVIM', "#{RbConfig.ruby} #{MOCK_VIM}")
-        stub_const('VimGolf::CLI::GOLFSHOWDIFF', "/bin/sh #{MOCK_DIFF}")
+        stub_const('VimGolf::CLI::GOLFSHOWDIFF', "#{RbConfig.ruby} #{MOCK_DIFF} -u")
 
         expect(VimGolf.ui).to receive(:ask_question)
           .with('Choice> ', type: :warn, choices: [:diff, :retry, :quit])

--- a/spec/lib/mock_bin/mock_diff.rb
+++ b/spec/lib/mock_bin/mock_diff.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'diff/lcs'
+require 'diff/lcs/ldiff'
+
+$stdout = File.open(File.join(ENV['HOME'], 'diff-output.txt'), 'w')
+
+exit Diff::LCS::Ldiff.run(ARGV)

--- a/spec/lib/mock_bin/mock_diff.sh
+++ b/spec/lib/mock_bin/mock_diff.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Need to redirect output here, because capture_stdout() in Ruby
-# doesn't cover calls using Kernel.system().
-
-diff -u "$@" >"$HOME/diff-output.txt"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'simplecov'
-SimpleCov.start 'rails'
+require 'simplecov-cobertura'
+SimpleCov.start 'rails' do
+  formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::CoberturaFormatter
+  ])
+end
 
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path('../config/environment', __dir__)


### PR DESCRIPTION
We run the following jobs on it:
- Rubocop (Ruby linter.)
- RSpec tests for the Rails application:
  - On Linux (Ubuntu), using SQLite3. Upload code coverage report from this specific run.
  - On MacOS, using SQLite3, to confirm it's a safe platform for development of the Rails app.
  - On Linux, using PostgreSQL as a test backend, to confirm changes developed against SQLite3 are not breaking under PostgreSQL.
- RSpec tests for the client Gem:
  - On all of Linux, MacOS and Windows.
  - Ruby versions starting at 2.1.9 and going all the way to 3.0 (some versions on select platforms, as relevant.)
  - Test coverage should ensure our code runs on a wide range of OS platforms and a wide range of Ruby versions.
  - (Note: Ruby 2.0 is missing from this list and the client gem and client tests work on that version of Ruby, but unfortunately it's not currently available on GitHub Actions. We still have a test running on Travis-CI for that version.)

Code coverage information is uploaded to [codecov.io](https://about.codecov.io/), which seems to have very nice interface to display coverage information and produce a neat dashboard with metrics on it.

This PR also includes a commit to fix a test case spawing an external diff to use a Ruby implementation of it (so it works on Windows, which we're now testing) and another commit to export the coverage report in an XML format that [codecov.io](https://about.codecov.io/) understands.

Tested:
 - GitHub Actions run for this branch on my fork: https://github.com/filbranden/vimgolf/actions/runs/887025987
 - Code coverage report: https://codecov.io/gh/filbranden/vimgolf/list/ccdda39e8ae5629157dbefba1df7f809f63274d6
 - Code coverage sunburst graph: https://codecov.io/gh/filbranden/vimgolf/commit/ccdda39e8ae5629157dbefba1df7f809f63274d6/graphs/sunburst

