### PR TITLE
Add tests for client gem on Ruby 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,15 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ruby-version:
-          - '2.3.8'
-          - '2.4.10'
-          - '2.7.3'
-          - '3.0.1'
+          - '2.3'
+          - '2.4'
+          - '2.7'
+          - '3.0'
         include:
           - os: ubuntu-latest
-            ruby-version: '2.1.9'
+            ruby-version: '2.1'
           - os: windows-latest
-            ruby-version: '2.7.3'
+            ruby-version: '2.7'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out git tree

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
         include:
           - os: ubuntu-latest
             ruby-version: '2.1'
+          - os: ubuntu-latest
+            ruby-version: '2.0'
+          - os: macos-latest
+            ruby-version: '2.0'
           - os: windows-latest
             ruby-version: '2.7'
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Ruby 2.0 was initially not available through setup-ruby in GitHub Actions, but I managed to get that enabled in https://github.com/ruby/setup-ruby/pull/182. We were testing for Ruby 2.0 compatibility in Travis-CI. Ruby 2.0 is old, but it's still somewhat available in CentOS 7, so let's keep compatibility with it for a little while longer...

Furthermore, this PR is using short Ruby versions in setup-ruby, since the code in setup-ruby will pick the latest patch version in that minor version when it finds a version with only 2 components. This ensures we'll be using the latest version of each family and will pick up newer patch versions whenever made available from setup-ruby.