### PR TITLE
Always display ranking for each challenge in User page.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run RSpec tests
         run: bundle exec rake
       - name: Upload coverage information
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.5.0
         with:
           files: ./coverage/coverage.xml
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
     user = User.where(nickname: params[:username]).first
     return redirect_to root_path unless user
 
-    @show_profile = ShowProfile.new(user, params[:ranking])
+    @show_profile = ShowProfile.new(user)
 
     respond_to do |format|
       format.html

--- a/app/repositories/repository_challenge.rb
+++ b/app/repositories/repository_challenge.rb
@@ -91,7 +91,7 @@ module RepositoryChallenge
     User.find(player_id).challenges
   end
 
-  def self.player_best_scores(player_id, _with_ranking = false)
+  def self.player_best_scores(player_id)
     User.find(player_id).player_best_scores
   end
 

--- a/app/services/show_profile.rb
+++ b/app/services/show_profile.rb
@@ -6,12 +6,10 @@ require 'forwardable'
 class ShowProfile
   extend Forwardable
 
-  def initialize(player, show_ranking = false)
+  def initialize(player)
     @player = player
-    @show_ranking = show_ranking
   end
   attr_reader :player
-  attr_reader :show_ranking
 
   def_delegators :player, :nickname
   def_delegators :player, :name
@@ -23,7 +21,7 @@ class ShowProfile
   end
 
   def tried_challenges
-    @tried_challenges ||= RepositoryChallenge.player_best_scores(player.id, show_ranking).to_a
+    @tried_challenges ||= RepositoryChallenge.player_best_scores(player.id).to_a
   end
 
 end

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -7,9 +7,7 @@
             <ul>
               <li>Best score: <b><%= entry.challenge.best_score %></b></li>
               <li>Best player score: <b><%= entry.score %></b></li>
-            <% if @show_profile.show_ranking %>
               <li>Position: <b>#<%= entry.position %> / <%= entry.challenge.count_uniq_users %></b></li>
-            <% end %>
               <li>Number of attempts: <b><%= link_to entry.challenge.count_entries_by(@show_profile.player.id),
                 user_challenge_path(entry.challenge.urlkey, @show_profile.nickname) %></b></li>
             </ul>

--- a/spec/repositories/repository_challenge_spec.rb
+++ b/spec/repositories/repository_challenge_spec.rb
@@ -350,7 +350,7 @@ describe RepositoryChallenge do
       end
 
       it 'return expected user information about the user' do
-        result = RepositoryChallenge.player_best_scores(user.id, true)
+        result = RepositoryChallenge.player_best_scores(user.id)
         expect(result.size).to eq(1)
         entry = result.first
         challenge = entry.challenge
@@ -379,7 +379,7 @@ describe RepositoryChallenge do
       end
 
       it 'return expected user information about the user' do
-        result = RepositoryChallenge.player_best_scores(user.id, true)
+        result = RepositoryChallenge.player_best_scores(user.id)
         expect(result.size).to eq(2)
 
         # Ensure challenges are in chronological order, challenge2 is first.


### PR DESCRIPTION
We've been already using the query that calculates it anyways and performance hasn't been a problem, so let's go ahead and remove it from hidden by a URL parameter to always available.