### PR TITLE
Enable codecov checks for project + patch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
This will allow codecov to post checks indicating whether the codecoverage after a PR is still acceptable.

The checks try to enforce coverage is at least preserved in the code ("auto"), with a threshold of up to 1% drop still being acceptable.

Tested:
    
    $ curl --data-binary @.codecov.yml https://codecov.io/validate
    Valid!
    
    {
      "coverage": {
        "status": {
          "project": {
            "default": {
              "target": "auto",
              "threshold": 1.0
            }
      curl    },
          "patch": {
            "default": {
              "target": "auto"
            }
          }
        }
      }
    }
    
Also confirmed that the codecov/patch and codecov/project checks were posted on the PR and that a Codecov Report was posted by the codecov-commenter bot.
