### PR TITLE
Force HTTPS everywhere.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Use Rails-provided config.force_ssl to redirect to the HTTPS version whenever the HTTP version is hit.

Furthermore, switch our identicon source to use HTTPS instead, to prevent any warnings about mixed content.

Tested on staging environment: access http://vimgolf-staging.herokuapp.com/ and confirm it redirects to HTTPS. Also checked that the identicons are served using HTTPS and no mixed content warnings are displayed on the browser.

(NOTE: The production environment is slightly different from the staging one, in that for the production HTTPS is done by Cloudflare, redirecting to HTTP on Heroku, while on the staging environment both HTTP and HTTPS are served by Heroku. Even then, the Rails force_ssl with the redirect should still work fine on both. In any case, if something goes awry we can always rollback the version to prior to this commit and come up with a different approach if needed.)

Fixes #299.