### PR TITLE
Support XDG base directory specification

### DIFF
--- a/lib/vimgolf/lib/vimgolf/config.rb
+++ b/lib/vimgolf/lib/vimgolf/config.rb
@@ -2,11 +2,13 @@ module VimGolf
   class Config
     class << self
       def path
-        "#{ENV['HOME']}/.vimgolf"
+        config_dir = ENV['XDG_CONFIG_HOME'] || "#{ENV['HOME']}/.config"
+        config_dir + "/vimgolf"
       end
 
       def put_path
-        path + "/put"
+        cache_dir = ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache"
+        cache_dir + "/vimgolf"
       end
 
       def save(conf)
@@ -15,9 +17,32 @@ module VimGolf
         end
       end
 
+      def _remove_old_dir
+        old_dir = "#{ENV['HOME']}/.vimgolf"
+        old_put_dir = old_dir + "/put"
+        Dir.each_child(old_put_dir) do |f|
+          File.unlink(old_put_dir + '/' + f)
+        end
+        Dir.rmdir(old_put_dir)
+        File.unlink(old_dir + '/config.yaml')
+        Dir.rmdir(old_dir)
+      end
+
       def load
-        File.open(path + '/config.yaml', 'r') do |f|
-          YAML.load(f)
+        old_path = "#{ENV['HOME']}/.vimgolf/config.yaml"
+        if File.file?(old_path) then
+          File.open(old_path, 'r') do |f|
+            conf = YAML.load(f)
+            _remove_old_dir
+            FileUtils.mkdir_p path
+            FileUtils.mkdir_p put_path
+            save(conf)
+            return conf
+          end
+        else
+          File.open(path + '/config.yaml', 'r') do |f|
+            return YAML.load(f)
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #285.

Support the XDG base directory specification
(https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
by moving the following files:

$HOME/.vimgolf/config.yaml --> {$XDG_CONFIG_HOME OR $HOME/.config}/vimgolf/config.yaml
$HOME/.vimgolf/put/* --> {$XDG_CACHE_HOME OR $HOME/.cache}/vimgolf/*

If the old directory (~/.vimgolf) exists, grab the key from there,
remove ~/.vimgolf and create the two xdg directories from above.