### PR TITLE
Use ruby_identicon to produce an identicon as a data URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'sprockets-rails', '~> 2.0'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.0.3'
 gem 'kaminari'
+gem 'ruby_identicon'
 
 gem 'vimgolf', path: 'lib/vimgolf'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chunky_png (1.4.0)
     climate_control (1.0.0)
     cliver (0.3.2)
     codeclimate-test-reporter (1.0.9)
@@ -256,6 +257,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby_identicon (0.0.6)
+      chunky_png (~> 1.4.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -343,6 +346,7 @@ DEPENDENCIES
   rubocop (~> 1.9.1)
   rubocop-rails
   rubocop-rspec
+  ruby_identicon
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def twitter_avatar(user)
-    "<img src='http://identicon-1132.appspot.com/#{Digest::MD5.hexdigest(user)}' class='user'>".html_safe
+    "<img src='data:image/png;base64,#{RubyIdenticon.create_base64(user, square_size: 6, grid_size: 8, border_size: 0)}' class='user'>".html_safe
   end
 
   def current_url


### PR DESCRIPTION
This removes an external dependency that has been broken for a while.

The ruby_identicon gem produces a PNG image in a format that is suitable to use in a `data:` URL, which also reduces the number of HTTP connections needed to properly render a page.

Tweak the identicon size to match our 48x48 space reserved for images.

Tested: Actually pushed to both vimgolf-staging and production already.