### PR TITLE
Fix tests for vimgolf gem on Ruby 2.0

### DIFF
--- a/lib/vimgolf/vimgolf.gemspec
+++ b/lib/vimgolf/vimgolf.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 12.3", ">= 12.3.1"
   s.add_development_dependency "climate_control", "~> 0.2"
   s.add_development_dependency "diff-lcs", "~> 1.4"
-  s.add_development_dependency "rexml", "~> 3.1.9"
+  s.add_development_dependency "rexml", "= 3.1.9"
   s.add_development_dependency "webmock", "~> 3.13"
 
   s.files         = Dir.glob("{bin,lib}/**/*") + %w(README.md)


### PR DESCRIPTION
Pin rexml at 3.1.9 for vimgolf gem testing. The newer 3.1.9.1 fails on Ruby 2.0, so let's pin the version of this Gem in
order to still be able to test on Ruby 2.0.

Ruby 2.0 is fairly old, but some Linux distributions that still get some use ship it by default, so let's try to prolong Ruby 2.0 support a little bit longer.