### PR TITLE
Update Docker client image to one with more recent Vim and set up GitHub actions to keep it up-to-date

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,0 +1,41 @@
+name: Vimgolf Docker client
+on:
+  schedule:
+    - cron: '30 5 * * 2'
+  workflow_dispatch: {}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out git tree
+        uses: actions/checkout@v2
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=raw,value={{date 'YYYYMMDD'}},prefix=manual-,enable=${{ github.event_name == 'workflow_dispatch' }}
+          flavor: |
+            latest=true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: client/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ $> vimgolf setup
 $> vimgolf put [challenge ID]
 ```
 
-## Golfing without ruby installation: [use docker](https://hub.docker.com/r/hettomei/vimgolf/)
+## Golfing without ruby installation: [use docker](https://github.com/filbranden/vimgolf/pkgs/container/vimgolf)
 
 ```
-$> docker run --rm -it -e "key=YOUR_VIMGOLF_KEY" hettomei/vimgolf challenge_ID
+$> docker run --rm -it -e "key=YOUR_VIMGOLF_KEY" ghcr.io/filbranden/vimgolf challenge_ID
 ```
 
 # Playing from other editors

--- a/app/views/main/about.erb
+++ b/app/views/main/about.erb
@@ -71,8 +71,8 @@
     <ul>
         <li><b>Golfing through a proxy:</b> set your "<b>http_proxy</b>" environment variable to URL of proxy</li>
         <li><b>Custom diff's &amp; flags:</b> set your "<b>DIFF</b>" environment variable (<a href="https://github.com/igrigorik/vimgolf/commit/d69469a93b404c4358b23fc1c4c7556a9563577e">d6946</a>)</li>
-        <li><b>Golfing without ruby installation:</b> <a href="https://hub.docker.com/r/hettomei/vimgolf/">use docker</a><br />
-          <code>docker run --rm -it -e "key=YOUR_VIMGOLF_KEY" hettomei/vimgolf challenge_ID</code>
+        <li><b>Golfing without ruby installation:</b> <a href="https://github.com/filbranden/vimgolf/pkgs/container/vimgolf">use docker</a><br />
+          <code>docker run --rm -it -e "key=YOUR_VIMGOLF_KEY" ghcr.io/filbranden/vimgolf challenge_ID</code>
         </li>
 
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:stable-slim
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ruby \
+		vim \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN gem install vimgolf
+
+RUN useradd -m -c 'Vim Golfer' golfer
+
+COPY run-vimgolf.sh /usr/local/bin/run-vimgolf
+
+USER golfer
+
+WORKDIR /home/golfer
+
+ENTRYPOINT ["/usr/local/bin/run-vimgolf"]
+
+CMD []

--- a/client/run-vimgolf.sh
+++ b/client/run-vimgolf.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$key" ]; then
+  cat <<EDQ >&2
+error: Missing VimGolf user key.
+
+Pass your VimGolf key into the container as an environment variable:
+  -e "key=..."
+
+Example:
+  % docker run -it --rm -e "key=<vimgolf_personal_key>" ghcr.io/filbranden/vimgolf <vimgolf_challenge_ID>
+EDQ
+  exit 1
+fi
+
+echo "$key" | vimgolf setup >/dev/null
+exec vimgolf put "$@"


### PR DESCRIPTION
Include a Dockerfile and launcher script in the main repository.

Set up GitHub action to build the image and push it to the GitHub Container Registry, do so weekly in order to keep it updated, with recent updates to the Debian Linux distribution, the Vim binary shipped by Debian, and any changes pushed to the vimgolf gem as well.

The new image is much smaller than the one originally built by Hettomei (40MiB vs 366MiB compressed, relevant for network transfers, and 140MiB vs 1GiB uncompressed, relevant when stored on disk).

The new image is also built for both 64-bit x86 and 64-bit ARM, which makes it also work on the Macbook M1.

I updated the instructions to point to the containers being built in my fork of the repository, where the GitHub Action has been running for a while. Once this PR is merged, the Action should start running here too and container images will be built here as well, so we can update the instructions to point to this one instead.

Fixes #352.
