### PR TITLE
Increase Cuprite timeout and Ferrum::Browser process timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
   rspec-rails:
     runs-on: ubuntu-latest
+    env:
+      FERRUM_PROCESS_TIMEOUT: 30
     steps:
       - name: Check out git tree
         uses: actions/checkout@v2
@@ -34,6 +36,8 @@ jobs:
 
   rspec-rails-macos:
     runs-on: macos-latest
+    env:
+      FERRUM_PROCESS_TIMEOUT: 30
     steps:
       - name: Check out git tree
         uses: actions/checkout@v2
@@ -57,6 +61,7 @@ jobs:
     env:
       DATABASE_ADAPTER: pg
       DATABASE_URL: postgresql://vimgolfgh:vimgolfpw@localhost/
+      FERRUM_PROCESS_TIMEOUT: 30
     steps:
       - name: Check out git tree
         uses: actions/checkout@v2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ require 'shoulda/matchers'
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800])
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800], timeout: 15)
 end
 Capybara.server = :webrick
 


### PR DESCRIPTION
Increase Cuprite timeout from 5 to 15 seconds.

We've been seeing Ferrum::TimeoutError in GitHub Actions runs, so let's increase the Curpite timeout which will hopefully take care of fixing that issue when the runner is overloaded.

Increase Ferrum::Browser process timeout from 10 to 30.

We've seen Ferrum::ProcessTimeoutError in GitHub Actions CI runs, so let's increase the process timeout from 10 to 30 using the environment variable recognized by Ferrum.