### PR TITLE
Bump up bundle cache version in setup-ruby in MacOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1
       - name: Run RSpec tests
         run: bundle exec rake
 


### PR DESCRIPTION
New macos-latest image 20220829.1 shipped a Homebrew change that reconfigured the directory layout of the Postgres 14 setup, which changed the location of the `libpq.5.dylib` library that is used by the pg gem.

The setup-ruby action caches gems so we don't have to rebuild and reinstall them across runs, so it turns out we were using an older pg gem built against the old Postgres, but with the new one installed in the image, therefore the gem was having trouble finding the dynamic libpq it needed.

In order to make this work again, bump up the cache version of setup-ruby, so that it builds the native pg gem once again, against the new Postgres library location.

Tested: CI [passes](https://github.com/filbranden/vimgolf/runs/8141356065?check_suite_focus=true) after this change.

Fixes: actions/runner-images#6173