### PR TITLE
Drop dependencies on MongoDB libraries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ gem 'rails', '~> 5.2.0'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
-gem 'mongo', '~> 2.5.0'
-gem 'bson', '~> 4.3.0'
-gem 'mongoid', '~> 6.1.0'
-
 gem 'pg'
 
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,6 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
-    bson (4.3.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.35.3)
@@ -139,11 +138,6 @@ GEM
     mini_racer (0.4.0)
       libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
-    mongo (2.5.3)
-      bson (>= 4.3.0, < 5.0.0)
-    mongoid (6.1.1)
-      activemodel (~> 5.0)
-      mongo (>= 2.4.1, < 3.0.0)
     msgpack (1.4.2)
     newrelic_rpm (7.0.0)
     nio4r (2.5.7)
@@ -314,7 +308,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
-  bson (~> 4.3.0)
   capybara
   climate_control
   codeclimate-test-reporter (~> 1.0.0)
@@ -330,8 +323,6 @@ DEPENDENCIES
   listen (~> 3.2)
   memcachier
   mini_racer
-  mongo (~> 2.5.0)
-  mongoid (~> 6.1.0)
   newrelic_rpm
   omniauth (~> 2.0)
   omniauth-rails_csrf_protection (~> 1.0)

--- a/app/controllers/entry_controller.rb
+++ b/app/controllers/entry_controller.rb
@@ -25,7 +25,7 @@ class EntryController < ApplicationController
       if @challenge && @user
         @entry = Entry.new(
                   script: params[:entry],
-                  score: VimGolf::Keylog.parse(params[:entry]).score
+                  score: VimGolf::Keylog.new(params[:entry]).score
                  )
         @entry.created_at = Time.now.utc
         @entry.user = @user

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,6 +1,6 @@
 class EntryValidator < ActiveModel::Validator
   def validate(entry)
-    k = VimGolf::Keylog.parse(entry.script).convert
+    k = VimGolf::Keylog.new(entry.script).convert
     entry.errors[:entry] << "Entry cannot be empty" if k.empty?
     entry.errors[:entry] << "Entry is too large" if k.length > MAX_FILESIZE
   end

--- a/app/services/submissions.rb
+++ b/app/services/submissions.rb
@@ -23,7 +23,7 @@ class Submissions
   end
 
   def users
-    @users ||= User.where(:id.in => user_ids).inject({}) {|h,u| h.merge(u.id => u)}
+    @users ||= User.where(id: user_ids).inject({}) {|h,u| h.merge(u.id => u)}
   end
 
   def user_ids

--- a/app/views/shared/_submissions.erb
+++ b/app/views/shared/_submissions.erb
@@ -9,7 +9,7 @@
     </h6>
 
 <pre style="margin-bottom:0">
-<% VimGolf::Keylog.parse(solution.script, solution.created_at).each do |key| %><% if key.size > 1 %><span class="entry-script"><%= key %></span><% else %><%= key %><% end %><% end %>
+<% VimGolf::Keylog.new(solution.script, solution.created_at).each do |key| %><% if key.size > 1 %><span class="entry-script"><%= key %></span><% else %><%= key %><% end %><% end %>
 </pre>
 
   <% solution.comments.each do |c| %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,6 +1,5 @@
 # Load the Rails application.
 require_relative 'application'
-require 'keylog'
 
 include TweetButton
 

--- a/lib/keylog.rb
+++ b/lib/keylog.rb
@@ -1,8 +1,0 @@
-module VimGolf
-  class Keylog
-    def self.parse(input, time=Time.now.utc)
-      input = input.data if input.is_a? BSON::Binary
-      VimGolf::Keylog.new(input || '', time)
-    end
-  end
-end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -43,7 +43,7 @@ describe Entry do
 
   describe 'Validations' do
     it 'is not valid without script' do
-      entry = build(:entry, script: nil)
+      entry = build(:entry, script: '')
 
       expect(entry).to_not be_valid
     end


### PR DESCRIPTION
We're now on Postgres, so drop the gems that are related to MongoDB.

This uncovered a few issues, mainly code that was working around some MongoDB BSON encoding, also using the `Symbol#in` method for ActiveRecord `where()` queries and also some simplification was possible by dropping `Keylog#parse` in favor of using `new()` directly.

Tested: `bundle exec rspec` passes. Also pushed the code to vimgolf-staging and confirmed it works as exepcted by navigating and using the website, also playing some challenges.