### PR TITLE
Switch from deprecated dalli_store to official mem_cache_store.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -65,7 +65,7 @@ module Vimgolf
     # a migration.
     config.active_record.sqlite3.represent_boolean_as_integer = true
 
-    config.cache_store = :dalli_store,
+    config.cache_store = :mem_cache_store,
                     (ENV["MEMCACHIER_SERVERS"] || "").split(","),
                     {
                       :username => ENV["MEMCACHIER_USERNAME"],


### PR DESCRIPTION
As recommended in dalli_store deprecation note, which gets logged on the warning log on server or rspec tests:

```
DEPRECATION: :dalli_store will be removed in Dalli 3.0.
Please use Rails' official :mem_cache_store instead.
https://guides.rubyonrails.org/caching_with_rails.html
```

Tested: locally and pushed to staging.