### PR TITLE
Replace <C-C><C-C> with <C-C>

### DIFF
--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -9,6 +9,9 @@ module VimGolf
       # Force encoding of solution text. Must match string literals.
       # .force_encoding CHANGES THE ORIGINAL STRING!
       @input = input.force_encoding(Encoding::ASCII_8BIT)
+      # Vim intentionally replaces <C-C> with <C-C><C-C> (Vim #11541).
+      # Convert <C-C><C-C> back to <C-C> (VimGolf #224).
+      @input = @input.gsub("\x03\x03", "\x03")
       @time = time
     end
 

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -9,7 +9,7 @@ module VimGolf
       # Force encoding of solution text. Must match string literals.
       # .force_encoding CHANGES THE ORIGINAL STRING!
       # Vim intentionally replaces "<C-C>" (\x03) with "<C-C><C-C>" (Vim #11541).
-      # Convert "<C-C><C-C>"" back to "<C-C>"" (VimGolf #224).
+      # Convert "<C-C><C-C>" back to "<C-C>" (VimGolf #224).
       @input = input.force_encoding(Encoding::ASCII_8BIT).gsub("\x03\x03", "\x03")
       @time = time
     end

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -8,10 +8,9 @@ module VimGolf
     def initialize(input, time=Time.now.utc)
       # Force encoding of solution text. Must match string literals.
       # .force_encoding CHANGES THE ORIGINAL STRING!
-      @input = input.force_encoding(Encoding::ASCII_8BIT)
-      # Vim intentionally replaces <C-C> with <C-C><C-C> (Vim #11541).
-      # Convert <C-C><C-C> back to <C-C> (VimGolf #224).
-      @input = @input.gsub("\x03\x03", "\x03")
+      # Vim intentionally replaces "<C-C>" (\x03) with "<C-C><C-C>" (Vim #11541).
+      # Convert "<C-C><C-C>"" back to "<C-C>"" (VimGolf #224).
+      @input = input.force_encoding(Encoding::ASCII_8BIT).gsub("\x03\x03", "\x03")
       @time = time
     end
 


### PR DESCRIPTION
Vim intentionally replaces `<C-C>` with `<C-C><C-C>`, which is reflected in the output when using `-W` (https://github.com/vim/vim/issues/11541).

In VimGolf, when a user enters `<C-C>`, the input will count as two keystrokes towards the score, showing `<C-C>` twice in the displayed keystrokes.

This PR updates the code to replace `<C-C><C-C>` with `<C-C>`. This will allow the CLI to not double count `<C-C>` in the reported keystrokes and score. My motivation for handling this in `keylog.rb`, rather than e.g., `cli.rb`, is that the server code would be able to utilize this update as well. However, without updating the database, which [appears to save scores](https://github.com/igrigorik/vimgolf/blob/77c370dc2cf840025847f0974459db6588628298/db/schema.rb#L42-L52), the scores would presumably still be incorrect for _already-submitted_ solutions.

This fixes #224.