### PR TITLE
Replace <C-C><C-C> with <C-C>

### DIFF
--- a/lib/vimgolf/lib/vimgolf/cli.rb
+++ b/lib/vimgolf/lib/vimgolf/cli.rb
@@ -138,6 +138,9 @@ module VimGolf
         system(*vimcmd) # assembled as an array, bypasses the shell
 
         if $?.exitstatus.zero?
+          # Vim intentionally replaces "<C-C>" (\x03) with "<C-C><C-C>" (Vim #11541).
+          # Update the log file so that "<C-C><C-C>" is converted back to "<C-C>" (VimGolf #224).
+          IO.binwrite(challenge.log_path, IO.binread(challenge.log_path).gsub("\x03\x03", "\x03"))
           log = Keylog.new(IO.binread(challenge.log_path))
 
           VimGolf.ui.info "\nHere are your keystrokes:"


### PR DESCRIPTION
Vim intentionally replaces `<C-C>` with `<C-C><C-C>`, which is reflected in the output when using `-W` (https://github.com/vim/vim/issues/11541).

In VimGolf, when a user enters `<C-C>`, the input will count as two keystrokes towards the score, showing `<C-C>` twice in the displayed keystrokes.

This PR updates the code to replace `<C-C><C-C>` with `<C-C>`. My [earlier PR](https://github.com/igrigorik/vimgolf/pull/366) handled this in `keylog.rb`, but I thought it would be undesirable to have this handled that way since it could result in users with old clients seeing keystrokes and scores in their client that differ from what's reported by the webapp once they upload. The approach in this PR handles the issue as soon as possible, rather than have it persist and be corrected only when keystrokes and scores are displayed.

The replacement of `<C-C><C-C>` to `<C-C>` is written to disk, since the log file is used later (when uploading). The code could be refactored to 1) avoid reading from disk twice and 2) only writing to disk when the log file has changed, but I preferred the currently implemented approach.

If you're interested in the general type of update in this PR (replacing `<C-C><C-C>` with `<C-C>`, with various possibilities for the actual implementation), please let me know if you have any requested changes.

This fixes #224.