### PR TITLE
Switch Docker client Vim to use `encoding=utf-8`

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,6 +18,8 @@ USER golfer
 
 WORKDIR /home/golfer
 
+ENV LANG=C.UTF-8
+
 ENTRYPOINT ["/usr/local/bin/run-vimgolf"]
 
 CMD []


### PR DESCRIPTION
Currently Docker client Vim uses `encoding=latin1`.

This makes it very hard to compete in challenges with unicode symbols (For example, [9v006637d03a00000000026f](https://www.vimgolf.com/challenges/9v006637d03a00000000026f))

This PR switches Docker client Vim to use `encoding=utf-8`.