### PR TITLE
Ignore \xfd\x6d Focus keys

### DIFF
--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -266,6 +266,7 @@ module VimGolf
       "\xfd\x61" => nil, # Focus Gained (GVIM) (>7.4.1433)
       "\xfd\x62" => nil, # Focus Gained (GVIM)
       "\xfd\x63" => nil, # Focus Lost (GVIM)
+      "\xfd\x6d" => nil, # Focus (GVIM)
     })
   end
 end

--- a/lib/vimgolf/lib/vimgolf/keylog.rb
+++ b/lib/vimgolf/lib/vimgolf/keylog.rb
@@ -266,7 +266,8 @@ module VimGolf
       "\xfd\x61" => nil, # Focus Gained (GVIM) (>7.4.1433)
       "\xfd\x62" => nil, # Focus Gained (GVIM)
       "\xfd\x63" => nil, # Focus Lost (GVIM)
-      "\xfd\x6d" => nil, # Focus (GVIM)
+
+      "\xfd\x6d" => nil, # Ignore <OSC>
     })
   end
 end


### PR DESCRIPTION
Vimgolf already filter out  some vim window focus keys. 
I am adding one more that is missing. 
Without it the output is: "Here are your keystrokes: fd-6d fd-6d:q<CR>". 
This will fix the client side only.  And should be apply to server side as well.

